### PR TITLE
Added temporal HTTPs redirect

### DIFF
--- a/templates/api-gateway-ingress.yml
+++ b/templates/api-gateway-ingress.yml
@@ -8,6 +8,7 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"
     #Routed Service recives HTTPS connections
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
 spec:
   rules:
   - host: {{.Values.domain}}


### PR DESCRIPTION
This is a temporal fix until finding out why the API GW 301 is ignored by the ingress