### PR TITLE
Fixing RabbitMQ in fast-lane

### DIFF
--- a/scripts/lamassu-fast-lane.sh
+++ b/scripts/lamassu-fast-lane.sh
@@ -138,7 +138,8 @@ fi
 
 function install_rabbitmq() {
     $kube $helm repo add bitnami https://charts.bitnami.com/bitnami
-    $kube $helm install rabbitmq bitnami/rabbitmq -n $NAMESPACE --set fullnameOverride=rabbitmq --set auth.username=$RABBIT_USER --set auth.password=$RABBIT_PWD
+    $kube $helm repo update
+    $kube $helm install rabbitmq bitnami/rabbitmq --version 12.6.0 -n $NAMESPACE --set fullnameOverride=rabbitmq --set auth.username=$RABBIT_USER --set auth.password=$RABBIT_PWD
     if [ $? -eq 0 ]; then
         echo -e "\n${GREEN}RabbitMQ installed${NOCOLOR}"
     else


### PR DESCRIPTION
I recently discovered that for some reason, the latest version of RabbitMQ makes Lamassu fail after installing it from the fast-lane script. Therefore, I modified the script and I put a specific version of RabbitMQ, that is a bit older.