### PR TITLE
Enable aws-connector only when awsConnector.enabled is true

### DIFF
--- a/charts/lamassu/templates/aws-connector-configmap.yml
+++ b/charts/lamassu/templates/aws-connector-configmap.yml
@@ -1,3 +1,4 @@
+{{- if .Values.services.awsConnector.enabled }}
 kind: ConfigMap
 apiVersion: v1
 metadata:
@@ -47,3 +48,4 @@ data:
       access_key_id: {{ .Values.services.awsConnector.credentials.accessKeyId }}
       secret_access_key:  {{ .Values.services.awsConnector.credentials.secretAccessKey }}
       region:  {{ .Values.services.awsConnector.credentials.region }}
+{{- end -}}

--- a/charts/lamassu/templates/aws-connector-deployment.yml
+++ b/charts/lamassu/templates/aws-connector-deployment.yml
@@ -1,3 +1,4 @@
+{{- if .Values.services.awsConnector.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:  
@@ -33,4 +34,5 @@ spec:
         - name: config
           configMap:  
             name: aws-connector-config
+{{- end -}}
 


### PR DESCRIPTION
AWS connector is being configured even when the property awsConnector.enabled is set to false. 

This PRs adds enabled propery check at configmap and deployment template files