### PR TITLE
Fixes Keycloak authority properties setting in values file.

### DIFF
--- a/scripts/lamassu-fast-lane.sh
+++ b/scripts/lamassu-fast-lane.sh
@@ -178,16 +178,6 @@ services:
       password: "env.keycloak.password"
 EOF
 
-if [ $DOMAIN != "dev.lamassu.io" ]; 
-then 
-    cat >>lamassu.yaml <<"EOF"
-auth: 
- oidc:
-   frontend:
-     authority: https://env.lamassu.domain/auth/realms/lamassu
-EOF
-fi
-
     sed 's/env.lamassu.domain/'"$DOMAIN"'/' -i lamassu.yaml
     sed 's/env.postgre.user/'"$POSTGRES_USER"'/;s/env.postgre.password/'"$POSTGRES_PWD"'/' -i lamassu.yaml
     sed 's/env.rabbitmq.user/'"$RABBIT_USER"'/;s/env.rabbitmq.password/'"$RABBIT_PWD"'/' -i lamassu.yaml


### PR DESCRIPTION
I think that setting the authority URL when the domain specified in the script differs from the default one is not needed now.

According to the [values.yaml](https://github.com/lamassuiot/lamassu-helm/blob/main/charts/lamassu/values.yaml) in the Lamassu chart this is done dynamically with the window hostname. 

```
auth:
  oidc:
    frontend:
      clientId: "frontend"
      authority: https://${window.location.hostname}/auth/realms/lamassu
```

I've checked and it seems it's working correctly with the change. @jjrodrig Check if you see any problem.