### PR TITLE
Fastlane: Fix auth creds with quotes in postgres helm value files

### DIFF
--- a/scripts/lamassu-fast-lane.sh
+++ b/scripts/lamassu-fast-lane.sh
@@ -390,8 +390,8 @@ fullnameOverride: "postgresql"
 global:
   postgresql:
     auth:
-      username: env.user
-      password: env.password
+      username: "env.user"
+      password: "env.password"
 primary:
   initdb:
     scripts:


### PR DESCRIPTION
if non standard chars are used such as "#@|" the installation process would fail. this fixes this issue