### PR TITLE
Bugfix: Honor certificate duration for CertManager-controled RootCA 

### DIFF
--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -52,7 +52,7 @@ jobs:
           helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo update
           helm install rabbitmq bitnami/rabbitmq --version 12.6.0 -n lamassu-test --set fullnameOverride=rabbitmq --set auth.username=admin --set auth.password=admin
-          helm install postgres bitnami/postgresql -n lamassu-test -f .github/ci/postgres.yaml --wait
+          helm install postgres bitnami/postgresql --version 15.5.11 -n lamassu-test -f .github/ci/postgres.yaml --wait
 
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'

--- a/charts/lamassu/ci/min-values.yaml
+++ b/charts/lamassu/ci/min-values.yaml
@@ -26,3 +26,4 @@ ingress:
   domain: ci.lamassu.io
   annotations: |
     kubernetes.io/ingress.class: "public"
+  

--- a/charts/lamassu/ci/min-values.yaml
+++ b/charts/lamassu/ci/min-values.yaml
@@ -1,0 +1,28 @@
+postgres:
+  hostname: "postgresql"
+  port: 5432
+  username: "admin"
+  password: "admin"
+
+amqp:
+  hostname: "rabbitmq"
+  port: 5672
+  username: "admin"
+  password: "admin"
+  tls: false
+services:
+  keycloak:
+    enabled: true
+    image: ghcr.io/lamassuiot/keycloak:2.1.0
+    adminCreds:
+      username: "admin"
+      password: "admin"
+auth:
+  oidc:
+    frontend:
+      authority: https://ci.lamassu.io/auth/realms/lamassu
+ingress:
+  enabled: true
+  domain: ci.lamassu.io
+  annotations: |
+    kubernetes.io/ingress.class: "public"

--- a/charts/lamassu/ci/min-values.yaml
+++ b/charts/lamassu/ci/min-values.yaml
@@ -26,4 +26,3 @@ ingress:
   domain: ci.lamassu.io
   annotations: |
     kubernetes.io/ingress.class: "public"
-  

--- a/charts/lamassu/templates/downstream-certmanager-issuer-certificate.yml
+++ b/charts/lamassu/templates/downstream-certmanager-issuer-certificate.yml
@@ -5,7 +5,7 @@ metadata:
   namespace: {{.Release.Namespace}}
 spec:
   isCA: true
-  duration: {{.Values.tls.duration}}
+  duration: {{.Values.tls.certManagerOptions.duration}}
   commonName: "downstream-selfsigned-cert"
   secretName: root-downstream-cert
   privateKey:


### PR DESCRIPTION
Root CA certificate had an invalid Values property reference. This PR fixes the broken reference