### PR TITLE
Allow access to VA endpoints via HTTP

### DIFF
--- a/charts/lamassu/templates/api-gateway-configmap.yml
+++ b/charts/lamassu/templates/api-gateway-configmap.yml
@@ -71,6 +71,19 @@ data:
                         - name: backend
                           domains: ["*"]
                           routes:
+                            - match:
+                                prefix: "/api/va/"
+                              route:
+                                prefix_rewrite: "/"
+                                cluster: va_cluster
+                              typed_per_filter_config:
+                                envoy.filters.http.ext_authz:
+                                  "@type": type.googleapis.com/envoy.extensions.filters.http.ext_authz.v3.ExtAuthzPerRoute
+                                  disabled: true
+                                envoy.filters.http.jwt_authn:
+                                  "@type": type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
+                                  disabled: true
+                            - match: { prefix: "/" }
                             - match: { prefix: "/" }
                               redirect:
                                 path_redirect: "/"

--- a/charts/lamassu/templates/api-gateway-configmap.yml
+++ b/charts/lamassu/templates/api-gateway-configmap.yml
@@ -84,7 +84,6 @@ data:
                                   "@type": type.googleapis.com/envoy.extensions.filters.http.jwt_authn.v3.PerRouteConfig
                                   disabled: true
                             - match: { prefix: "/" }
-                            - match: { prefix: "/" }
                               redirect:
                                 path_redirect: "/"
                                 https_redirect: true

--- a/charts/lamassu/templates/api-gateway-ingress.yml
+++ b/charts/lamassu/templates/api-gateway-ingress.yml
@@ -9,7 +9,7 @@ metadata:
     nginx.ingress.kubernetes.io/ssl-passthrough: "true"
     #Routed Service recives HTTPS connections
     nginx.ingress.kubernetes.io/backend-protocol: "HTTPS"
-    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "false"
 spec:
   # ingressClassName: nginx 
   rules:


### PR DESCRIPTION
Allow to access OCSP/CRL endpoints over HTTP. It is a recommendation of RFCs.