### PR TITLE
Activates legacy observability interface

### DIFF
--- a/scripts/lamassu-fast-lane.sh
+++ b/scripts/lamassu-fast-lane.sh
@@ -473,6 +473,8 @@ extraEnvVars:
     value: "false"
   - name: KC_HEALTH_ENABLED
     value: "true"
+  - name: KC_LEGACY_OBSERVABILITY_INTERFACE
+    value: "true"
   - name: HTTP_ADDRESS_FORWARDING
     value: "true"
   - name: QUARKUS_HTTP_ACCESS_LOG_ENABLED


### PR DESCRIPTION
Keycloak [has changed ](https://www.keycloak.org/server/configuration#_creating_the_initial_admin_user)default port for metrics and health endpoints to 9000. So, actually if that port is not exposed, health endpoints are not reachable. In order to use the legacy ports this env variable must be set (KC_LEGACY_OBSERVABILITY_INTERFACE).

This [issue ](https://github.com/bitnami/charts/issues/28630)talks about the same problem.