### PR TITLE
documenting upgrade process

### DIFF
--- a/charts/lamassu/CHANGELOG/3.1.1->3.2.0.md
+++ b/charts/lamassu/CHANGELOG/3.1.1->3.2.0.md
@@ -1,0 +1,145 @@
+The new helm chart version 3.2.0 introduces a new structure for the configuration of the **crypto engines** and **connectors**. The new structure is more flexible and allows for a more detailed configuration of the crypto engines and connectors without coupling them too much to the helm chart itself. 
+
+## Crypto Engines
+
+Previously, crypto engines were defined under the `services.ca.engines` key. In the new version, the crypto engines are defined under the `services.ca.cryptoEngines` key. The new structure allows for a more detailed configuration of the crypto engines. The `type` key is used to define the type of the crypto engine. The following types are supported: `filesystem`, `aws_kms`, `aws_secrets_manager`, `pkcs11`, `hashicorp_vault`. There is no longer a dedicated map for each crypto engine, but a list of crypto engines. Engines now are defined as a list of items, where each item is a map with the following keys: `id`, `type`, and other keys that are specific to the crypto engine type (those properties have not changed at all).
+
+Another Key core change affects the old golang, now named filesystem engines. The `storage_directory` key now must point to  `/crypto/fs` instead of `/data`.
+
+OLD (3.1.1): 
+```yaml
+services:
+  ca:
+    engines:
+      defaultEngineID: "golang-1"
+      golang:
+        - id: golang-1
+          storage_directory: /data
+      awsKms:
+        - id: aws-kms-1
+          access_key_id: XXXXXXXXXX
+          secret_access_key: XXXXXXXXXX
+          region: eu-west-1
+          auth_method: static
+          metadata:
+            account: my-account
+      awsSecretsManager:
+        - id: awsm-1
+          access_key_id: XXXXXXXXXX
+          secret_access_key: XXXXXXXXXX
+          region: eu-west-1
+          auth_method: static
+          metadata:
+            account: my-account
+      pkcs11:
+        - id: pkcs11-1
+          token: lamassuHSM
+          pin: "1234"
+          module_path: /usr/local/lib/libpkcs11-proxy.so
+          module_extra_options:
+            env:
+              PKCS11_PROXY_SOCKET: tcp://hsm-softhsm:5657
+      hashicorpVault:
+        - id: hashicorp-vault-1
+          role_id: XXXXXXXXXX
+          secret_id: XXXXXXXXXX
+          auto_unseal_enabled: true          
+          mount_path: /secret
+          protocol: http
+          hostname: vault
+          port: 8200
+```
+
+NEW (3.2.0):
+```yaml
+services:
+  ca:
+    cryptoEngines:
+      defaultEngineID: "golang-1"
+      engines:
+        - id: golang-1
+          type: filesystem
+          storage_directory: /crypto/fs
+        - id: aws-kms-1
+          type: aws_kms
+          access_key_id: XXXXXXXXXX
+          secret_access_key: XXXXXXXXXX
+          region: eu-west-1
+          auth_method: static
+          metadata:
+            account: my-account
+        - id: awsm-1
+          type: aws_secrets_manager
+          access_key_id: XXXXXXXXXX
+          secret_access_key: XXXXXXXXXX
+          region: eu-west-1
+          auth_method: static
+          metadata:
+            account: my-account
+        - id: pkcs11-1
+          type: pkcs11
+          token: lamassuHSM
+          pin: "1234"
+          module_path: /usr/local/lib/libpkcs11-proxy.so
+          module_extra_options:
+            env:
+              PKCS11_PROXY_SOCKET: tcp://hsm-softhsm:5657
+        - id: hashicorp-vault-1
+          type: hashicorp_vault
+          role_id: XXXXXXXXXX
+          secret_id: XXXXXXXXXX
+          auto_unseal_enabled: true          
+          mount_path: /secret
+          protocol: http
+          hostname: vault
+          port: 8200
+```
+
+
+## Connectors
+
+Previously, connectors were only limited to AWS-based connectors,  defined under the `services.awsConnector` key. In the new version, the connectors are defined under the `services.connectors` key. The new structure allows for a more detailed configuration of the connectors. The `type` key is used to define the type of the connector. The following types are supported: `awsiot`, `emqx`. There is no longer a dedicated map for each connector, but a list of connectors. Connectors now are defined as a list of items, where each item is a map with the following keys: `id`, `type`, `image`, and other keys that are specific to the connector type (those properties have not changed at all).
+
+OLD (3.1.1): 
+```yaml
+services:
+  awsConnector:
+    image: ghcr.io/lamassuiot/lamassu-aws-connector:2.8.0
+    instances:
+    - connectorID: "aws.my-connector-1"
+      credentials:
+        auth_method: static
+        region: eu-west-1
+        access_key_id: XXXXXXXXXX
+        secret_access_key: XXXXXXXXXX 
+    - connectorID: "aws.my-connector-2"
+      credentials:
+        auth_method: static
+        region: eu-west-1
+        access_key_id: XXXXXXXXXX
+        secret_access_key: XXXXXXXXXX
+```
+
+NEW (3.2.0):
+```yaml
+services:
+  connectors:
+    - id: "aws.my-connector-1"
+      type: awsiot
+      image: ghcr.io/lamassuiot/lamassu-aws-connector:3.2.2
+      credentials:
+        auth_method: static
+        region: eu-west-1
+        access_key_id: XXXXXXXXXX
+        secret_access_key: XXXXXXXXXX 
+    - id: "aws.my-connector-2"
+      type: awsiot
+      image: ghcr.io/lamassuiot/lamassu-aws-connector:3.2.2
+      credentials:
+        auth_method: static
+        region: eu-west-1
+        access_key_id: XXXXXXXXXX
+        secret_access_key: XXXXXXXXXX 
+    - id: "emqx.my-connector-1"
+      type: emqx
+```


### PR DESCRIPTION
This pull request documents the changes to the configuration structure for crypto engines and connectors in the helm chart version 3.2.0. The new structure allows for more detailed and flexible configurations.

Changes to crypto engines and connectors:

* **Crypto Engines**:
  - Crypto engines are now defined under the `services.ca.cryptoEngines` key instead of `services.ca.engines`.
  - The `type` key is introduced to define the type of the crypto engine, supporting types such as `filesystem`, `aws_kms`, `aws_secrets_manager`, `pkcs11`, and `hashicorp_vault`.
  - The `storage_directory` key for filesystem engines must now point to `/crypto/fs` instead of `/data`.

* **Connectors**:
  - Connectors are now defined under the `services.connectors` key instead of `services.awsConnector`.
  - The `type` key is introduced to define the type of the connector, supporting types such as `awsiot` and `emqx`.