### PR TITLE
feat: support multiple oidc providers

### DIFF
--- a/charts/lamassu/CHANGELOG/3.3.0->3.3.1.md
+++ b/charts/lamassu/CHANGELOG/3.3.0->3.3.1.md
@@ -1,0 +1,31 @@
+# Migration guide from 3.3.0 to 3.3.1
+
+
+### UPDATED auth.oidc.apiGateway
+
+Starting from version 3.3.1 it is allowed to define a collection of JWKS providers to support multiple OIDC providers. 
+
+**OLD (3.3.0):**
+```yaml
+auth:
+  oidc:
+    apiGateway: 
+      jwks:
+        protocol: http
+        host: keycloak
+        port: 80
+        path: /auth/realms/lamassu/protocol/openid-connect/certs
+```
+
+**NEW (3.3.1):**
+```yaml
+auth:
+  oidc:
+    apiGateway: 
+      jwks:
+        - name: oidc-authn
+          protocol: http
+          host: keycloak
+          port: 80
+          path: /auth/realms/lamassu/protocol/openid-connect/certs
+```

--- a/charts/lamassu/templates/envoy-jwt-securitypolicy.yml
+++ b/charts/lamassu/templates/envoy-jwt-securitypolicy.yml
@@ -19,18 +19,24 @@ spec:
     allowCredentials: true
   jwt:
     providers:
-    - name: oidc-authn
-      remoteJWKS:
-        uri: "{{ .Values.auth.oidc.apiGateway.jwks.protocol }}://{{ .Values.auth.oidc.apiGateway.jwks.host }}.{{ .Release.Namespace }}:{{ .Values.auth.oidc.apiGateway.jwks.port }}{{ .Values.auth.oidc.apiGateway.jwks.path }}"
+    {{- range $.Values.auth.oidc.apiGateway.jwks }}
+      - name: {{ .name }}
+        remoteJWKS:
+          uri: "{{ .protocol }}://{{ .host }}.{{ $.Release.Namespace }}:{{ .port }}{{ .path }}"
+    {{- end }}
+    
   authorization:
     defaultAction: Deny
     rules:
-    - name: "allow"
-      action: Allow
-      principal:
+    {{- range $.Values.auth.oidc.apiGateway.jwks }}
+     - name: "allow"
+       action: Allow
+       principal:
         jwt:
-          provider: oidc-authn
+          provider: {{ .name }}
           claims:
-          - name: {{ .Values.auth.authorization.rolesClaim }}
+          - name: {{ $.Values.auth.authorization.rolesClaim }}
             valueType: StringArray
-            values: ["{{ .Values.auth.authorization.roles.admin }}"]
+            values: ["{{ $.Values.auth.authorization.roles.admin }}"]
+    {{- end }}
+    

--- a/charts/lamassu/values.yaml
+++ b/charts/lamassu/values.yaml
@@ -62,14 +62,15 @@ auth:
     apiGateway:
       # -- URL pointing to the issuer's public key set to validate the JWT tokens.
       jwks:
-        # -- Protocol to use to fetch the public key set. Allowed values are: `http`, `https`
-        protocol: http
-        # -- Hostname to use to fetch the public key set
-        host: keycloak
-        # -- Port to use to fetch the public key set
-        port: 80
-        # -- Path to use to fetch the public key set
-        path: /auth/realms/lamassu/protocol/openid-connect/certs
+        - name: oidc-authn
+          # -- Protocol to use to fetch the public key set. Allowed values are: `http`, `https`
+          protocol: http
+          # -- Hostname to use to fetch the public key set
+          host: keycloak
+          # -- Port to use to fetch the public key set
+          port: 80
+          # -- Path to use to fetch the public key set
+          path: /auth/realms/lamassu/protocol/openid-connect/certs
   authorization:
     # -- Claim to use to find and filter the user's roles
     rolesClaim: realm_access.roles

--- a/scripts/lamassu-fast-lane.sh
+++ b/scripts/lamassu-fast-lane.sh
@@ -313,9 +313,10 @@ auth:
   oidc:
     apiGateway:
       jwks:
-        protocol: http
-        host: auth-keycloak
-        port: 80
+        - name: oidc-authn
+          protocol: http
+          host: auth-keycloak
+          port: 80
 
 gateway:
   extraRouting:


### PR DESCRIPTION
This pull request introduces changes to improve the flexibility and scalability of JWT authentication configuration in the `lamassu` chart. The changes include modifying the `envoy-jwt-securitypolicy.yml` template to support multiple JWKS providers and updating the corresponding values in `values.yaml` and `lamassu-fast-lane.sh`.

Improvements to JWT authentication configuration:

* [`charts/lamassu/templates/envoy-jwt-securitypolicy.yml`](diffhunk://#diff-325d1555b6bbaf44e75c95287bdacc86663aae5c1467dce468e59c0ffc685ea5L22-R42): Modified the template to iterate over multiple JWKS providers, allowing for more flexible JWT authentication configuration.

Updates to configuration files:

* [`charts/lamassu/values.yaml`](diffhunk://#diff-c8871a1c9de696262b2e8e6313ca62e1ee9bc76e986902009f013b6777b8b729R65): Added support for specifying multiple JWKS providers in the `auth.apiGateway.jwks` section.
* [`scripts/lamassu-fast-lane.sh`](diffhunk://#diff-c8d88062314a6c49eb30af61ed678f39dfacf991a00bb3d329cebd01bfada9bbR316): Updated the script to include the new JWKS provider configuration.