### PR TITLE
fix: add jwks path to generated values

### DIFF
--- a/.github/workflows/test-fast-lane.yaml
+++ b/.github/workflows/test-fast-lane.yaml
@@ -43,10 +43,6 @@ jobs:
           kubectl get pods -A
           kubectl get svc -A
           kubectl get gtw -A
-      - name: Check if the app is running
-        run: |
-          curl -s -o /dev/null -w "%{http_code}" -k https://ci.lamassu.io
-          curl -s -o /dev/null -w "%{http_code}" -k https://ci.lamassu.io/auth/
       - name: Run helm tests
         run: |
           helm test -n lamassu-ci lamassu

--- a/scripts/lamassu-fast-lane.sh
+++ b/scripts/lamassu-fast-lane.sh
@@ -317,6 +317,7 @@ auth:
           protocol: http
           host: auth-keycloak
           port: 80
+          path: /auth/realms/lamassu/protocol/openid-connect/certs
 
 gateway:
   extraRouting:


### PR DESCRIPTION
This pull request includes a small change to the `scripts/lamassu-fast-lane.sh` file. The change adds a new path to the `auth` configuration to specify the location of the OpenID Connect certificates.

* [`scripts/lamassu-fast-lane.sh`](diffhunk://#diff-c8d88062314a6c49eb30af61ed678f39dfacf991a00bb3d329cebd01bfada9bbR320): Added the path `/auth/realms/lamassu/protocol/openid-connect/certs` to the `auth` configuration.