### PR TITLE
feat: simplify jwks uri definition

### DIFF
--- a/charts/lamassu/CHANGELOG/3.3.0->3.3.1.md
+++ b/charts/lamassu/CHANGELOG/3.3.0->3.3.1.md
@@ -3,7 +3,11 @@
 
 ### UPDATED auth.oidc.apiGateway
 
-Starting from version 3.3.1 it is allowed to define a collection of JWKS providers to support multiple OIDC providers. 
+Starting from version 3.3.1 it is allowed to define a collection of JWKS providers to support multiple OIDC providers. Bare in mind, if authentication service is deployed in kubernetes, since the gateway is deployed in its own Namespace, you will need to indicate not only the hostname but the namespace as well to have a FQDN to access the authn service as indicated in [Kubernetes docs](https://kubernetes.io/docs/concepts/services-networking/dns-pod-service/).
+
+> [!WARNING]
+> The following example assumes the auth service is deployed in `lamassu-dev` namespace. Change it accordingly.
+
 
 **OLD (3.3.0):**
 ```yaml
@@ -12,7 +16,7 @@ auth:
     apiGateway: 
       jwks:
         protocol: http
-        host: keycloak
+        host: auth-keycloak
         port: 80
         path: /auth/realms/lamassu/protocol/openid-connect/certs
 ```
@@ -24,8 +28,5 @@ auth:
     apiGateway: 
       jwks:
         - name: oidc-authn
-          protocol: http
-          host: keycloak
-          port: 80
-          path: /auth/realms/lamassu/protocol/openid-connect/certs
+          uri: http://auth-keycloak.lamassu-dev/auth/realms/lamassu/protocol/openid-connect/certs
 ```

--- a/charts/lamassu/templates/envoy-jwt-securitypolicy.yml
+++ b/charts/lamassu/templates/envoy-jwt-securitypolicy.yml
@@ -22,7 +22,7 @@ spec:
     {{- range $.Values.auth.oidc.apiGateway.jwks }}
       - name: {{ .name }}
         remoteJWKS:
-          uri: "{{ .protocol }}://{{ .host }}.{{ $.Release.Namespace }}:{{ .port }}{{ .path }}"
+          uri: "{{ .uri }}"
     {{- end }}
     
   authorization:

--- a/charts/lamassu/values.yaml
+++ b/charts/lamassu/values.yaml
@@ -64,14 +64,8 @@ auth:
       # -- URL pointing to the issuer's public key set to validate the JWT tokens.
       jwks:
         - name: oidc-authn
-          # -- Protocol to use to fetch the public key set. Allowed values are: `http`, `https`
-          protocol: http
-          # -- Hostname to use to fetch the public key set
-          host: keycloak
-          # -- Port to use to fetch the public key set
-          port: 80
-          # -- Path to use to fetch the public key set
-          path: /auth/realms/lamassu/protocol/openid-connect/certs
+          # -- URI to use to fetch the public key set
+          uri: http://keycloak/auth/realms/lamassu/protocol/openid-connect/certs
   authorization:
     # -- Claim to use to find and filter the user's roles
     rolesClaim: realm_access.roles


### PR DESCRIPTION
This pull request includes changes to the JWT security policy configuration in the `lamassu` chart. The primary focus is on simplifying the configuration by consolidating multiple fields into a single URI field.

Configuration simplification:

* [`charts/lamassu/templates/envoy-jwt-securitypolicy.yml`](diffhunk://#diff-325d1555b6bbaf44e75c95287bdacc86663aae5c1467dce468e59c0ffc685ea5L25-R25): Updated the `remoteJWKS` configuration to use a single `uri` field instead of separate fields for protocol, host, port, and path.
* [`charts/lamassu/values.yaml`](diffhunk://#diff-c8871a1c9de696262b2e8e6313ca62e1ee9bc76e986902009f013b6777b8b729L67-R68): Simplified the JWKS configuration by replacing the separate fields (`protocol`, `host`, `port`, and `path`) with a single `uri` field.