### PR TITLE
fix: rename crypto_monitoring attribute to certificate_monitoring_job

### DIFF
--- a/charts/lamassu/templates/ca-configmap.yml
+++ b/charts/lamassu/templates/ca-configmap.yml
@@ -41,7 +41,7 @@ data:
       engines:      
         {{ .Values.services.ca.cryptoEngines.engines | toYaml | indent 4 | nindent 4 | trim  }}
         
-    crypto_monitoring:
+    certificate_monitoring_job:
       enabled: true
       frequency: "{{ .Values.services.ca.monitoring.frequency }}"
       automatic_ca_rotation:


### PR DESCRIPTION
This pull request renames crypto_monitoring attribute to certificate_monitoring_job as it is expected by the CA service.

- [charts/lamassu/templates/ca-configmap.yml](https://github.com/lamassuiot/lamassu-helm/compare/hotfix/certificate_monitoring_job?expand=1#diff-24e93dad814b720ed77e433bc501505c2e38e59c7c46b476f8966aca3757bddb): renames crypto_monitoring attribute to certificate_monitoring_job

Fixes #56 