### PR TITLE
feat: disable CA key migration

### DIFF
--- a/charts/lamassu/templates/ca-configmap.yml
+++ b/charts/lamassu/templates/ca-configmap.yml
@@ -36,6 +36,7 @@ data:
       password: "{{ $.Values.postgres.password }}"
 
     crypto_engines:
+      migrate_keys_format: false
       log_level: "trace"
       default_id: {{ .Values.services.ca.cryptoEngines.defaultEngineID }}
       engines:      
@@ -47,6 +48,7 @@ data:
       automatic_ca_rotation:
         enabled: false
         renewal_delta: "1d"
+    
         
     va_server_domains:
     {{ range $.Values.services.ca.domains }}


### PR DESCRIPTION
This pull request makes minor updates to the `ca-configmap.yml` file in the `charts/lamassu/templates` directory. The changes primarily involve adding new configuration options for the CA service.

Configuration updates:

* Added a new `migrate_keys_format` option under `crypto_engines` and set its default value to `false`.
* Added spacing adjustments for readability near the `va_server_domains` configuration.