### PR TITLE
Add AMQP-based DLQ event bus subscriber configuration to service Helm chart configmaps

### DIFF
--- a/charts/lamassu/templates/alert-configmap.yml
+++ b/charts/lamassu/templates/alert-configmap.yml
@@ -27,6 +27,19 @@ data:
         username: "{{ .Values.amqp.username }}"
         password: "{{ .Values.amqp.password }}"
 
+    subscriber_dlq_event_bus:
+      log_level: "debug"
+      enabled: true
+      provider: amqp
+      protocol: amqp #amqp | amqps
+      hostname: {{ .Values.amqp.hostname }}
+      port: {{ .Values.amqp.port }}
+      exchange: lamassu-dlq
+      basic_auth:
+        enabled: true
+        username: "{{ .Values.amqp.username }}"
+        password: "{{ .Values.amqp.password }}"
+
     storage:
       log_level: "info"
       provider: "postgres" #couch_db | postgres | dynamo_db

--- a/charts/lamassu/templates/aws-connector-configmap.yml
+++ b/charts/lamassu/templates/aws-connector-configmap.yml
@@ -22,6 +22,19 @@ data:
         enabled: true
         username: {{ $.Values.amqp.username }}
         password: {{ $.Values.amqp.password }}
+        
+    subscriber_dlq_event_bus:
+      log_level: "debug"
+      enabled: true
+      provider: amqp
+      protocol: amqp #amqp | amqps
+      hostname: {{ $.Values.amqp.hostname }}
+      port: {{ $.Values.amqp.port }}
+      exchange: lamassu-dlq
+      basic_auth:
+        enabled: true
+        username: "{{ $.Values.amqp.username }}"
+        password: "{{ $.Values.amqp.password }}"
 
     dms_manager_client:
       log_level: debug

--- a/charts/lamassu/templates/device-manager-configmap.yml
+++ b/charts/lamassu/templates/device-manager-configmap.yml
@@ -26,6 +26,19 @@ data:
         enabled: true
         username: "{{ .Values.amqp.username }}"
         password: "{{ .Values.amqp.password }}"
+        
+    subscriber_dlq_event_bus:
+      log_level: "debug"
+      enabled: true
+      provider: amqp
+      protocol: amqp #amqp | amqps
+      hostname: {{ .Values.amqp.hostname }}
+      port: {{ .Values.amqp.port }}
+      exchange: lamassu-dlq
+      basic_auth:
+        enabled: true
+        username: "{{ .Values.amqp.username }}"
+        password: "{{ .Values.amqp.password }}"
 
     publisher_event_bus:
       log_level: "debug"

--- a/charts/lamassu/templates/va-configmap.yaml
+++ b/charts/lamassu/templates/va-configmap.yaml
@@ -39,7 +39,20 @@ data:
         enabled: true
         username: "{{ .Values.amqp.username }}"
         password: "{{ .Values.amqp.password }}"
-    
+        
+    subscriber_dlq_event_bus:
+      log_level: "debug"
+      enabled: true
+      provider: amqp
+      protocol: amqp #amqp | amqps
+      hostname: {{ .Values.amqp.hostname }}
+      port: {{ .Values.amqp.port }}
+      exchange: lamassu-dlq
+      basic_auth:
+        enabled: true
+        username: "{{ .Values.amqp.username }}"
+        password: "{{ .Values.amqp.password }}"
+
     publisher_event_bus:
       log_level: "debug"
       enabled: true


### PR DESCRIPTION
This pull request adds configuration for a new AMQP-based Dead Letter Queue (DLQ) event bus subscriber to several service Helm chart configmaps. This will enable each service to handle messages that could not be processed by the main event bus, improving reliability and observability.

Configuration updates for DLQ event bus:

* Added a `subscriber_dlq_event_bus` section to the following configmaps, configuring an AMQP-based DLQ subscriber with debug log level, enabled status, and credentials sourced from existing AMQP values:
  * `charts/lamassu/templates/alert-configmap.yml`
  * `charts/lamassu/templates/aws-connector-configmap.yml`
  * `charts/lamassu/templates/device-manager-configmap.yml`
  * `charts/lamassu/templates/va-configmap.yaml`