### PR TITLE
Enhance lamassu-fast-lane.sh with Keycloak theme v2.0.0 support

### DIFF
--- a/scripts/lamassu-fast-lane.sh
+++ b/scripts/lamassu-fast-lane.sh
@@ -506,7 +506,7 @@ extraVolumeMounts:
 initContainers:
 - name: init-custom-theme
   image: curlimages/curl:8.10.1
-  command: ['sh', '-c', 'curl -L -f -S -o /extensions/lamassu-theme.jar https://github.com/lamassuiot/keycloak-theme/releases/download/1.0.0/keycloak-theme-for-kc-22-and-above.jar']
+  command: ['sh', '-c', 'curl -L -f -S -o /extensions/lamassu-theme.jar https://github.com/lamassuiot/keycloak-theme/releases/download/2.0.0/keycloak-theme-for-kc-22-to-25.jar']
   volumeMounts:  
   - mountPath: "/extensions"
     name: extensions


### PR DESCRIPTION
This pull request updates the custom theme initialization process in the `scripts/lamassu-fast-lane.sh` file to use a newer version of the Keycloak theme.

Theme update:

* Updated the `init-custom-theme` container to download version 2.0.0 of the Keycloak theme for versions 22 to 25, replacing the previous 1.0.0 version for "kc-22 and above".