### PR TITLE
Fix/release420

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -73,7 +73,7 @@ jobs:
           yq eval '.services.dmsManager.image = "ghcr.io/lamassuiot/lamassu-dmsmanager:${{ github.event.inputs.app_version }}"' -i charts/${{ github.event.inputs.chart_to_release }}/values.yaml
           yq eval '.services.alerts.image = "ghcr.io/lamassuiot/lamassu-alerts:${{ github.event.inputs.app_version }}"' -i charts/${{ github.event.inputs.chart_to_release }}/values.yaml
           yq eval '.services.kms.image = "ghcr.io/lamassuiot/lamassu-kms:${{ github.event.inputs.app_version }}"' -i charts/${{ github.event.inputs.chart_to_release }}/values.yaml
-          yq eval '.migrations.image = "ghcr.io/lamassuiot/lamassu-db-migration:${{ github.event.inputs.app_version }}"' -i charts/${{ github.event.inputs.chart_to_release }}/values.yaml
+          yq eval '.migrations.image = "ghcr.io/lamassuiot/lamassu-lamassu-db-migration:${{ github.event.inputs.app_version }}"' -i charts/${{ github.event.inputs.chart_to_release }}/values.yaml
       
       - name: Generate charts changelog files
         shell: bash

--- a/charts/lamassu/templates/migration-job.yaml
+++ b/charts/lamassu/templates/migration-job.yaml
@@ -4,7 +4,7 @@ kind: Job
 metadata:
   name: migration-db-{{ $dbName }}
   annotations:
-    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook": pre-upgrade, pre-install
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   template:

--- a/charts/lamassu/templates/migration-job.yaml
+++ b/charts/lamassu/templates/migration-job.yaml
@@ -1,8 +1,10 @@
 {{- range $i, $dbName := .Values.migrations.databases }}
+---
 apiVersion: batch/v1
 kind: Job
 metadata:
   name: migration-db-{{ $dbName }}
+  namespace: {{ $.Release.Namespace }}
   annotations:
     "helm.sh/hook": pre-upgrade, pre-install
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded

--- a/charts/lamassu/templates/migration-job.yaml
+++ b/charts/lamassu/templates/migration-job.yaml
@@ -6,7 +6,7 @@ metadata:
   name: migration-db-{{ $dbName }}
   namespace: {{ $.Release.Namespace }}
   annotations:
-    "helm.sh/hook": pre-upgrade, pre-install
+    "helm.sh/hook": pre-upgrade,pre-install
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   template:

--- a/charts/lamassu/values.yaml
+++ b/charts/lamassu/values.yaml
@@ -132,13 +132,11 @@ services:
 toolbox:
   image: ghcr.io/lamassuiot/toolbox:2.2.0
 migrations:
-  image: ghcr.io/lamassuiot/lamassu-db-migration:3.7.0
+  image: ghcr.io/lamassuiot/lamassu-lamassu-db-migration:3.7.0
   databases:
-    - auth
     - alerts
     - ca
     - va
-    - cloudproxy
     - devicemanager
     - dmsmanager
     - kms

--- a/scripts/lamassu-fast-lane.sh
+++ b/scripts/lamassu-fast-lane.sh
@@ -21,18 +21,18 @@ TLS_KEY=
 
 POSTGRES_USER=admin
 POSTGRES_PWD=$(
-    shuf -er -n30  {A..Z} {a..z} {0..9} {.,@,$} | tr -d '\n'
+    shuf -er -n30  {A..Z} {a..z} {0..9} | tr -d '\n'
     echo
 )
 RABBIT_USER=admin
 RABBIT_PWD=$(
-    shuf -er -n30  {A..Z} {a..z} {0..9} {.,@,$} | tr -d '\n'
+    shuf -er -n30  {A..Z} {a..z} {0..9} | tr -d '\n'
     echo
 )
 
 KEYCLOAK_USER=admin
 KEYCLOAK_PWD=$(
-    shuf -er -n30  {A..Z} {a..z} {0..9} {.,@,$} | tr -d '\n'
+    shuf -er -n30  {A..Z} {a..z} {0..9} | tr -d '\n'
     echo
 )
 


### PR DESCRIPTION
This pull request makes several updates related to the database migration service and improves the deployment process. The most significant changes are the renaming of the database migration image, adjustment of migration job Helm hooks, and simplification of password generation in a script.

**Database migration image and configuration updates:**

* Changed the `migrations.image` reference in `.github/workflows/release.yaml` and `charts/lamassu/values.yaml` to use `ghcr.io/lamassuiot/lamassu-lamassu-db-migration` instead of the previous `lamassu-db-migration` image, aligning naming conventions and references throughout the deployment pipeline. [[1]](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL76-R76) [[2]](diffhunk://#diff-c8871a1c9de696262b2e8e6313ca62e1ee9bc76e986902009f013b6777b8b729L135-L141)
* Updated the list of databases for migration in `charts/lamassu/values.yaml` by removing `auth` and `cloudproxy`, ensuring only relevant databases are included in migration jobs.

**Helm migration job improvements:**

* Modified the Helm migration job template (`charts/lamassu/templates/migration-job.yaml`) to add the namespace to job metadata and trigger the migration job on both pre-upgrade and pre-install Helm hooks, ensuring migrations run during both installation and upgrade events.

**Script password generation:**

* Simplified password generation in `scripts/lamassu-fast-lane.sh` by removing special characters from the character set, likely to avoid issues with password parsing or compatibility.