### PR TITLE
feat: add pre-upgrade database migration hook for single-database architecture

### DIFF
--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -70,15 +70,15 @@ jobs:
           # CRITICAL: Wait for PostgreSQL to be fully ready before proceeding
           echo "Waiting for PostgreSQL to be fully operational..."
           kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=postgresql -n lamassu-test --timeout=300s
-          
+
           # Verify databases are created and PostgreSQL is accepting connections
           echo "Verifying PostgreSQL databases are initialized..."
-          kubectl run pg-check --image=postgres:17 --rm -i --restart=Never -n lamassu-test -- \
+          kubectl run pg-check --image=docker.io/bitnamilegacy/postgresql:17.6.0-debian-12-r4 --rm -i --restart=Never -n lamassu-test -- \
             psql "postgresql://admin:admin@postgresql:5432/auth" -c "SELECT 1" || \
             (echo "Database not ready, waiting longer..." && sleep 30 && \
-             kubectl run pg-check-retry --image=postgres:17 --rm -i --restart=Never -n lamassu-test -- \
+             kubectl run pg-check-retry --image=docker.io/bitnamilegacy/postgresql:17.6.0-debian-12-r4 --rm -i --restart=Never -n lamassu-test -- \
              psql "postgresql://admin:admin@postgresql:5432/auth" -c "SELECT 1")
-          
+
           echo "PostgreSQL is ready and databases are accessible"
 
           helm install auth bitnami/keycloak --version 25.2.0 -n lamassu-test -f .github/ci/keycloak.yaml --wait --timeout 600s

--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -1,11 +1,11 @@
 name: Lint and Test Charts
 
-on: 
+on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened]
   workflow_dispatch:
-    
+
 jobs:
   lint-test:
     runs-on: ubuntu-latest
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-python@v5.3.0
         with:
-          python-version: '3.9'
+          python-version: "3.9"
           check-latest: true
 
       - name: Set up chart-testing
@@ -35,11 +35,11 @@ jobs:
           if [[ -n "$changed" ]]; then
             echo "changed=true" >> "$GITHUB_OUTPUT"
           fi
-     
+
       - name: Run chart-testing (lint)
         if: steps.list-changed.outputs.changed == 'true'
         run: ct lint --charts charts/lamassu --github-groups --target-branch main
-      
+
       - name: Create kind cluster
         if: steps.list-changed.outputs.changed == 'true'
         uses: helm/kind-action@v1.12.0
@@ -53,7 +53,8 @@ jobs:
           kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.3/cert-manager.yaml
           helm repo add bitnami https://charts.bitnami.com/bitnami
           helm repo update
-          helm install eg oci://docker.io/envoyproxy/gateway-helm --version v1.3.0 -n envoy-gateway-system --create-namespace -f .github/ci/eg.yaml --wait
+          helm install eg oci://docker.io/envoyproxy/gateway-helm --version v1.3.0 -n envoy-gateway-system --create-namespace -f .github/ci/eg.yaml --wait --timeout 300s
+
           cat <<EOF | kubectl apply -f -
             apiVersion: gateway.networking.k8s.io/v1
             kind: GatewayClass
@@ -62,12 +63,17 @@ jobs:
             spec:
               controllerName: gateway.envoyproxy.io/gatewayclass-controller
           EOF
-                
-          kubectl create namespace lamassu-test
-          helm install postgres bitnami/postgresql --version 16.7.27 -n lamassu-test -f .github/ci/postgres.yaml --wait
-          helm install auth bitnami/keycloak --version 25.2.0 -n lamassu-test -f .github/ci/keycloak.yaml --wait
-          helm install rabbitmq bitnami/rabbitmq --version 12.6.0 -n lamassu-test -f .github/ci/rabbitmq.yaml --wait
 
+          kubectl create namespace lamassu-test
+          helm install postgres bitnami/postgresql --version 16.7.27 -n lamassu-test -f .github/ci/postgres.yaml --wait --timeout 600s
+
+          # CRITICAL: Wait for PostgreSQL to be fully ready before proceeding
+          echo "Waiting for PostgreSQL to be fully operational..."
+          kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=postgresql -n lamassu-test --timeout=300s
+          sleep 10  # Additional grace period for init scripts to complete
+
+          helm install auth bitnami/keycloak --version 25.2.0 -n lamassu-test -f .github/ci/keycloak.yaml --wait --timeout 300s
+          helm install rabbitmq bitnami/rabbitmq --version 12.6.0 -n lamassu-test -f .github/ci/rabbitmq.yaml --wait --timeout 300s
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'
         run: ct install --config .github/ci/ct.yaml --github-groups --target-branch main

--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -70,9 +70,18 @@ jobs:
           # CRITICAL: Wait for PostgreSQL to be fully ready before proceeding
           echo "Waiting for PostgreSQL to be fully operational..."
           kubectl wait --for=condition=Ready pod -l app.kubernetes.io/name=postgresql -n lamassu-test --timeout=300s
-          sleep 10  # Additional grace period for init scripts to complete
+          
+          # Verify databases are created and PostgreSQL is accepting connections
+          echo "Verifying PostgreSQL databases are initialized..."
+          kubectl run pg-check --image=postgres:17 --rm -i --restart=Never -n lamassu-test -- \
+            psql "postgresql://admin:admin@postgresql:5432/auth" -c "SELECT 1" || \
+            (echo "Database not ready, waiting longer..." && sleep 30 && \
+             kubectl run pg-check-retry --image=postgres:17 --rm -i --restart=Never -n lamassu-test -- \
+             psql "postgresql://admin:admin@postgresql:5432/auth" -c "SELECT 1")
+          
+          echo "PostgreSQL is ready and databases are accessible"
 
-          helm install auth bitnami/keycloak --version 25.2.0 -n lamassu-test -f .github/ci/keycloak.yaml --wait --timeout 300s
+          helm install auth bitnami/keycloak --version 25.2.0 -n lamassu-test -f .github/ci/keycloak.yaml --wait --timeout 600s
           helm install rabbitmq bitnami/rabbitmq --version 12.6.0 -n lamassu-test -f .github/ci/rabbitmq.yaml --wait --timeout 300s
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'

--- a/charts/lamassu/templates/single-db-migration-job.yml
+++ b/charts/lamassu/templates/single-db-migration-job.yml
@@ -1,0 +1,192 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: "single-db-migration-job-{{ .Release.Name }}"
+  annotations:
+    # This hook runs before upgrade to migrate from separate databases to single database with schemas
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-3"
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  template:
+    metadata:
+      name: "single-db-migration-job-{{ .Release.Name }}"
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: pre-upgrade-schema-migration-job
+          image: docker.io/bitnamilegacy/postgresql:17
+          env:
+            - name: POSTGRES_USER
+              value: "{{ .Values.postgres.username }}"
+            - name: POSTGRES_PASSWORD
+              value: "{{ .Values.postgres.password }}"
+            - name: POSTGRES_HOST
+              value: "{{ .Values.postgres.hostname }}"
+          command: ["bash", "-c"]
+          args:
+            - |
+              set -e
+
+              echo "=========================================="
+              echo "Starting Database Schema Migration"
+              echo "From: Separate databases per service"
+              echo "To: Single 'lamassu' database with schemas"
+              echo "=========================================="
+              echo ""
+
+              # List of services and their databases
+              SERVICES="{{ join " " .Values.migrations.databases }}"
+              TARGET_DB="lamassu"
+
+              # Function to check if database exists
+              check_db_exists() {
+                local db_name=$1
+                local result=$(PGPASSWORD=$POSTGRES_PASSWORD psql -h $POSTGRES_HOST -U $POSTGRES_USER -d postgres -tc "SELECT 1 FROM pg_database WHERE datname='$db_name'" | tr -d ' ')
+                echo "$result"
+              }
+
+              # Function to check if schema exists
+              check_schema_exists() {
+                local db_name=$1
+                local schema_name=$2
+                local result=$(PGPASSWORD=$POSTGRES_PASSWORD psql -h $POSTGRES_HOST -U $POSTGRES_USER -d "$db_name" -tc "SELECT 1 FROM information_schema.schemata WHERE schema_name='$schema_name'" | tr -d ' ')
+                echo "$result"
+              }
+
+              # Function to check if database has any tables
+              check_db_has_tables() {
+                local db_name=$1
+                local count=$(PGPASSWORD=$POSTGRES_PASSWORD psql -h $POSTGRES_HOST -U $POSTGRES_USER -d "$db_name" -tc "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = 'public'" | tr -d ' ')
+                echo "$count"
+              }
+
+              # Step 1: Check if migration has already been performed
+              echo "Step 1: Checking if migration has already been performed..."
+              if [ "$(check_db_exists $TARGET_DB)" == "1" ]; then
+                echo "  >> Target database '$TARGET_DB' already exists."
+                
+                # Check if all schemas exist
+                all_schemas_exist=true
+                for service in $SERVICES; do
+                  if [ "$(check_schema_exists $TARGET_DB $service)" != "1" ]; then
+                    all_schemas_exist=false
+                    break
+                  fi
+                done
+                
+                if [ "$all_schemas_exist" == "true" ]; then
+                  echo "  >> All service schemas already exist in '$TARGET_DB'."
+                  echo "  >> Migration appears to be already completed. Skipping..."
+                  exit 0
+                fi
+              fi
+              echo ""
+
+              # Step 2: Create target database if it doesn't exist
+              echo "Step 2: Creating target database '$TARGET_DB'..."
+              if [ "$(check_db_exists $TARGET_DB)" == "1" ]; then
+                echo "  >> Database '$TARGET_DB' already exists. Skipping creation."
+              else
+                echo "  >> Creating database '$TARGET_DB'..."
+                PGPASSWORD=$POSTGRES_PASSWORD psql -h $POSTGRES_HOST -U $POSTGRES_USER -d postgres -c "CREATE DATABASE $TARGET_DB;"
+                echo "  >> Database '$TARGET_DB' created successfully."
+              fi
+              echo ""
+
+              # Step 3: Migrate each service database to its own schema
+              for service in $SERVICES; do
+                echo "=========================================="
+                echo "Migrating service: $service"
+                echo "=========================================="
+                
+                # Check if source database exists
+                if [ "$(check_db_exists $service)" != "1" ]; then
+                  echo "  >> Source database '$service' does not exist. Skipping migration for this service..."
+                  echo ""
+                  continue
+                fi
+                
+                # Check if source database has any tables
+                table_count=$(check_db_has_tables $service)
+                if [ "$table_count" == "0" ]; then
+                  echo "  >> Source database '$service' has no tables. Skipping migration for this service..."
+                  echo ""
+                  continue
+                fi
+                
+                echo "  >> Source database '$service' exists with $table_count table(s)."
+                
+                # Check if target schema already exists
+                if [ "$(check_schema_exists $TARGET_DB $service)" == "1" ]; then
+                  echo "  >> Schema '$service' already exists in '$TARGET_DB'. Skipping migration for this service..."
+                  echo ""
+                  continue
+                fi
+                
+                # Create schema in target database
+                echo "  >> Creating schema '$service' in database '$TARGET_DB'..."
+                PGPASSWORD=$POSTGRES_PASSWORD psql -h $POSTGRES_HOST -U $POSTGRES_USER -d "$TARGET_DB" -c "CREATE SCHEMA IF NOT EXISTS $service;"
+                echo "  >> Schema '$service' created."
+                
+                # Dump the source database (schema and data)
+                echo "  >> Dumping data from database '$service'..."
+                PGPASSWORD=$POSTGRES_PASSWORD pg_dump -h $POSTGRES_HOST -U $POSTGRES_USER -d "$service" --schema=public --no-owner --no-acl > /tmp/${service}_dump.sql
+                
+                # Modify the dump to use the new schema
+                echo "  >> Adapting dump for schema '$service'..."
+                # Replace all references to 'public' schema with the service schema
+                sed -i "s/SCHEMA public/SCHEMA $service/g" /tmp/${service}_dump.sql
+                sed -i "s/search_path = public/search_path = $service/g" /tmp/${service}_dump.sql
+                sed -i "s/TO public;/TO $service;/g" /tmp/${service}_dump.sql
+                # Replace public. prefix with service schema (handles CREATE TABLE public.tablename)
+                sed -i "s/\bpublic\./$service\./g" /tmp/${service}_dump.sql
+                # Make CREATE SCHEMA idempotent
+                sed -i "s/CREATE SCHEMA $service;/CREATE SCHEMA IF NOT EXISTS $service;/g" /tmp/${service}_dump.sql
+                
+                # Import the modified dump into the new schema
+                echo "  >> Importing data into schema '$service' in database '$TARGET_DB'..."
+                PGPASSWORD=$POSTGRES_PASSWORD psql -h $POSTGRES_HOST -U $POSTGRES_USER -d "$TARGET_DB" < /tmp/${service}_dump.sql
+                
+                # Verify the migration
+                echo "  >> Verifying migration..."
+                target_table_count=$(PGPASSWORD=$POSTGRES_PASSWORD psql -h $POSTGRES_HOST -U $POSTGRES_USER -d "$TARGET_DB" -tc "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = '$service'" | tr -d ' ')
+                echo "  >> Migrated $target_table_count table(s) to schema '$service'."
+                
+                # Clean up dump file
+                rm -f /tmp/${service}_dump.sql
+                
+                echo "  >> Migration completed for service '$service'."
+                echo ""
+              done
+
+              # Step 4: Create migration marker table
+              echo "=========================================="
+              echo "Step 4: Creating migration marker..."
+              echo "=========================================="
+              PGPASSWORD=$POSTGRES_PASSWORD psql -h $POSTGRES_HOST -U $POSTGRES_USER -d "$TARGET_DB" -c "
+                CREATE TABLE IF NOT EXISTS public.migration_history (
+                  id SERIAL PRIMARY KEY,
+                  migration_name VARCHAR(255) NOT NULL,
+                  applied_at TIMESTAMP DEFAULT NOW() NOT NULL,
+                  description TEXT
+                );
+                
+                INSERT INTO public.migration_history (migration_name, description) 
+                VALUES ('schema_migration_v1', 'Migrated from separate databases to single database with schemas for: ca, devicemanager, dmsmanager, alerts, va');
+              "
+              echo "  >> Migration marker created."
+              echo ""
+
+              echo "=========================================="
+              echo "Database Schema Migration Completed!"
+              echo "=========================================="
+              echo ""
+              echo "Summary:"
+              echo "  - Target database: $TARGET_DB"
+              echo "  - Migrated services: $SERVICES"
+              echo ""
+              echo "IMPORTANT: Update your application configuration to use:"
+              echo "  - Database: $TARGET_DB"
+              echo "  - Schema search path: <service_name> (e.g., 'ca', 'devicemanager', etc.)"
+              echo "=========================================="

--- a/charts/lamassu/templates/single-db-migration-job.yml
+++ b/charts/lamassu/templates/single-db-migration-job.yml
@@ -127,7 +127,7 @@ spec:
                 
                 # Create schema in target database
                 echo "  >> Creating schema '$service' in database '$TARGET_DB'..."
-                PGPASSWORD=$POSTGRES_PASSWORD psql -h $POSTGRES_HOST -U $POSTGRES_USER -d "$TARGET_DB" -c "CREATE SCHEMA IF NOT EXISTS $service;"
+                PGPASSWORD=$POSTGRES_PASSWORD psql -v ON_ERROR_STOP=1 -h $POSTGRES_HOST -U $POSTGRES_USER -d "$TARGET_DB" -c "CREATE SCHEMA IF NOT EXISTS $service;"
                 echo "  >> Schema '$service' created."
                 
                 # Dump the source database (schema and data)
@@ -149,11 +149,11 @@ spec:
                 
                 # Import the modified dump into the new schema
                 echo "  >> Importing data into schema '$service' in database '$TARGET_DB'..."
-                PGPASSWORD=$POSTGRES_PASSWORD psql -h $POSTGRES_HOST -U $POSTGRES_USER -d "$TARGET_DB" < /tmp/${service}_dump.sql
+                PGPASSWORD=$POSTGRES_PASSWORD psql -v ON_ERROR_STOP=1 -h $POSTGRES_HOST -U $POSTGRES_USER -d "$TARGET_DB" < /tmp/${service}_dump.sql
                 
                 # Verify the migration
                 echo "  >> Verifying migration..."
-                target_table_count=$(PGPASSWORD=$POSTGRES_PASSWORD psql -h $POSTGRES_HOST -U $POSTGRES_USER -d "$TARGET_DB" -tc "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = '$service'" | tr -d ' ')
+                target_table_count=$(PGPASSWORD=$POSTGRES_PASSWORD psql -v ON_ERROR_STOP=1 -h $POSTGRES_HOST -U $POSTGRES_USER -d "$TARGET_DB" -tc "SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = '$service'" | tr -d ' ')
                 echo "  >> Migrated $target_table_count table(s) to schema '$service'."
                 
                 # Clean up dump file

--- a/charts/lamassu/templates/single-db-migration-job.yml
+++ b/charts/lamassu/templates/single-db-migration-job.yml
@@ -142,8 +142,8 @@ spec:
                 sed -E -i "s/^SET search_path = public;$/SET search_path = $service;/" /tmp/${service}_dump.sql
                 sed -E -i "s/\bIN SCHEMA public\b/IN SCHEMA $service/g" /tmp/${service}_dump.sql
                 sed -E -i "s/\bON SCHEMA public\b/ON SCHEMA $service/g" /tmp/${service}_dump.sql
-                # Replace public. prefix with service schema (handles CREATE TABLE public.tablename)
-                sed -E -i "s/\bpublic\./$service\./g" /tmp/${service}_dump.sql
+                # Replace public. schema qualifiers with the service schema using a basic sed-compatible boundary match
+                 sed -i "s/\(^\|[^[:alnum:]_]\)public\./\1$service\./g" /tmp/${service}_dump.sql
                 # Make CREATE SCHEMA idempotent
                 sed -E -i "s/CREATE SCHEMA $service;/CREATE SCHEMA IF NOT EXISTS $service;/g" /tmp/${service}_dump.sql
                 

--- a/charts/lamassu/templates/single-db-migration-job.yml
+++ b/charts/lamassu/templates/single-db-migration-job.yml
@@ -136,14 +136,16 @@ spec:
                 
                 # Modify the dump to use the new schema
                 echo "  >> Adapting dump for schema '$service'..."
-                # Replace all references to 'public' schema with the service schema
-                sed -i "s/SCHEMA public/SCHEMA $service/g" /tmp/${service}_dump.sql
-                sed -i "s/search_path = public/search_path = $service/g" /tmp/${service}_dump.sql
-                sed -i "s/TO public;/TO $service;/g" /tmp/${service}_dump.sql
+                # Replace common pg_dump references to the 'public' schema with the service schema
+                sed -E -i "s/\bSCHEMA public\b/SCHEMA $service/g" /tmp/${service}_dump.sql
+                sed -E -i "s/^SET search_path = public, pg_catalog;$/SET search_path = $service, pg_catalog;/" /tmp/${service}_dump.sql
+                sed -E -i "s/^SET search_path = public;$/SET search_path = $service;/" /tmp/${service}_dump.sql
+                sed -E -i "s/\bIN SCHEMA public\b/IN SCHEMA $service/g" /tmp/${service}_dump.sql
+                sed -E -i "s/\bON SCHEMA public\b/ON SCHEMA $service/g" /tmp/${service}_dump.sql
                 # Replace public. prefix with service schema (handles CREATE TABLE public.tablename)
-                sed -i "s/\bpublic\./$service\./g" /tmp/${service}_dump.sql
+                sed -E -i "s/\bpublic\./$service\./g" /tmp/${service}_dump.sql
                 # Make CREATE SCHEMA idempotent
-                sed -i "s/CREATE SCHEMA $service;/CREATE SCHEMA IF NOT EXISTS $service;/g" /tmp/${service}_dump.sql
+                sed -E -i "s/CREATE SCHEMA $service;/CREATE SCHEMA IF NOT EXISTS $service;/g" /tmp/${service}_dump.sql
                 
                 # Import the modified dump into the new schema
                 echo "  >> Importing data into schema '$service' in database '$TARGET_DB'..."

--- a/charts/lamassu/templates/single-db-migration-job.yml
+++ b/charts/lamassu/templates/single-db-migration-job.yml
@@ -15,7 +15,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: pre-upgrade-schema-migration-job
-          image: docker.io/bitnamilegacy/postgresql:17
+          image: docker.io/bitnamilegacy/postgresql:16.7.27
           env:
             - name: POSTGRES_USER
               value: "{{ .Values.postgres.username }}"

--- a/charts/lamassu/templates/single-db-migration-job.yml
+++ b/charts/lamassu/templates/single-db-migration-job.yml
@@ -2,6 +2,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: "single-db-migration-job-{{ .Release.Name }}"
+  namespace: "{{ .Release.Namespace }}"
   annotations:
     # This hook runs before upgrade to migrate from separate databases to single database with schemas
     "helm.sh/hook": pre-upgrade

--- a/charts/lamassu/templates/single-db-migration-job.yml
+++ b/charts/lamassu/templates/single-db-migration-job.yml
@@ -6,7 +6,7 @@ metadata:
     # This hook runs before upgrade to migrate from separate databases to single database with schemas
     "helm.sh/hook": pre-upgrade
     "helm.sh/hook-weight": "-3"
-    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
 spec:
   template:
     metadata:

--- a/charts/lamassu/templates/single-db-migration-job.yml
+++ b/charts/lamassu/templates/single-db-migration-job.yml
@@ -173,7 +173,7 @@ spec:
                 );
                 
                 INSERT INTO public.migration_history (migration_name, description) 
-                VALUES ('schema_migration_v1', 'Migrated from separate databases to single database with schemas for: ca, devicemanager, dmsmanager, alerts, va');
+                VALUES ('schema_migration_v1', 'Migrated from separate databases to single database with schemas for: $SERVICES');
               "
               echo "  >> Migration marker created."
               echo ""

--- a/charts/lamassu/templates/single-db-migration-job.yml
+++ b/charts/lamassu/templates/single-db-migration-job.yml
@@ -16,7 +16,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: pre-upgrade-schema-migration-job
-          image: docker.io/bitnamilegacy/postgresql:16.7.27
+          image: docker.io/bitnamilegacy/postgresql:17.6.0-debian-12-r4
           env:
             - name: POSTGRES_USER
               value: "{{ .Values.postgres.username }}"


### PR DESCRIPTION
This PR introduces a Helm pre-upgrade hook that automates the migration from the legacy multi-database architecture (separate databases per service) to the new single-database architecture with schema-based isolation.

## What Changed

### Migration Job

**New file:** `single-db-migration-job.yml`
   - Kubernetes Job that runs as a Helm pre-upgrade hook
   - Migrates data from individual service databases to schemas within a single `lamassu` database

The migration job:

1. **Checks if migration already completed** (idempotent - safe to run multiple times)
2. **Creates target database** (`lamassu`) if it doesn't exist
3. **For each service** (alerts, ca, devicemanager, dmsmanager, va, kms):
   - Verifies source database exists and has data
   - Creates schema in target database
   - Dumps source database using `pg_dump`
   - Transforms SQL dump to use new schema (replaces `public` with service name)
   - Imports data into new schema
   - Verifies table counts match
4. **Creates migration marker** in `public.migration_history` table for tracking

### CI/CD Improvements

Modified: `test-chart.yaml`

- Enhanced PostgreSQL readiness checks with database connectivity verification
- Added retry logic to ensure databases are fully initialized before dependent services start
- Increased Keycloak installation timeout from 300s to 600s to prevent premature timeouts
- Improved CI stability by verifying PostgreSQL accepts connections before proceeding

## Key Features

- ✅ **Idempotent**: Safe to run multiple times - skips already-migrated services
- ✅ **Non-destructive**: Original databases remain untouched
- ✅ **Automatic**: Runs before every helm upgrade (pre-upgrade hook)
- ✅ **Self-cleaning**: Job auto-deletes after successful completion
- ✅ **Dynamic**: Database list pulled from values.yaml (migrations.databases)
- ✅ **Version-aware**: Uses Bitnami PostgreSQL 17 image matching deployment stack
- ✅ **Reliable CI**: Enhanced readiness checks prevent race conditions in automated tests

## Notes

- Applications must be updated to connect to `lamassu` database and set appropriate `search_path`
- Original databases remain for rollback purposes (manual cleanup required)
- Migration marker stored in `public.migration_history table`

Closes #88 