### PR TITLE
feat: add CA-to-KMS key migration pre-upgrade hook

### DIFF
--- a/charts/lamassu/templates/ca-to-kms-migration-job.yaml
+++ b/charts/lamassu/templates/ca-to-kms-migration-job.yaml
@@ -1,30 +1,5 @@
 {{- if .Values.migrations.caToKms.enabled }}
 ---
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: {{ .Release.Name }}-ca-to-kms-migration-config
-  namespace: {{ .Release.Namespace }}
-  annotations:
-    "helm.sh/hook": pre-upgrade
-    "helm.sh/hook-weight": "-11"
-    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
-data:
-  config: |
-    log_level: info
-    ca_storage:
-      provider: postgres
-      hostname: {{ .Values.postgres.hostname }}
-      port: {{ .Values.postgres.port }}
-      username: {{ .Values.postgres.username }}
-      password: {{ .Values.postgres.password }}
-    kms_storage:
-      provider: postgres
-      hostname: {{ .Values.postgres.hostname }}
-      port: {{ .Values.postgres.port }}
-      username: {{ .Values.postgres.username }}
-      password: {{ .Values.postgres.password }}
----
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -45,16 +20,13 @@ spec:
         - name: ca-to-kms-migration
           image: {{ .Values.migrations.caToKms.image }}
           imagePullPolicy: {{ .Values.global.imagePullPolicy }}
-          env:
-            - name: LAMASSU_CONFIG_FILE
-              value: /etc/lamassuiot/config.yml
           volumeMounts:
-            - name: migration-config
+            - name: kms-config
               mountPath: /etc/lamassuiot/config.yml
               subPath: config
               readOnly: true
       volumes:
-        - name: migration-config
+        - name: kms-config
           configMap:
-            name: {{ .Release.Name }}-ca-to-kms-migration-config
+            name: kms-config
 {{- end }}

--- a/charts/lamassu/templates/ca-to-kms-migration-job.yaml
+++ b/charts/lamassu/templates/ca-to-kms-migration-job.yaml
@@ -1,0 +1,60 @@
+{{- if .Values.migrations.caToKms.enabled }}
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Release.Name }}-ca-to-kms-migration-config
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-11"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+data:
+  config: |
+    log_level: info
+    ca_storage:
+      provider: postgres
+      hostname: {{ .Values.postgres.hostname }}
+      port: {{ .Values.postgres.port }}
+      username: {{ .Values.postgres.username }}
+      password: {{ .Values.postgres.password }}
+    kms_storage:
+      provider: postgres
+      hostname: {{ .Values.postgres.hostname }}
+      port: {{ .Values.postgres.port }}
+      username: {{ .Values.postgres.username }}
+      password: {{ .Values.postgres.password }}
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-ca-to-kms-migration
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook": pre-upgrade
+    "helm.sh/hook-weight": "-10"
+    "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+spec:
+  backoffLimit: 3
+  template:
+    metadata:
+      name: ca-to-kms-migration
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: ca-to-kms-migration
+          image: {{ .Values.migrations.caToKms.image }}
+          imagePullPolicy: {{ .Values.global.imagePullPolicy }}
+          env:
+            - name: LAMASSU_CONFIG_FILE
+              value: /etc/lamassuiot/config.yml
+          volumeMounts:
+            - name: migration-config
+              mountPath: /etc/lamassuiot/config.yml
+              subPath: config
+              readOnly: true
+      volumes:
+        - name: migration-config
+          configMap:
+            name: {{ .Release.Name }}-ca-to-kms-migration-config
+{{- end }}

--- a/charts/lamassu/templates/migration-job.yaml
+++ b/charts/lamassu/templates/migration-job.yaml
@@ -1,4 +1,4 @@
-{{- range $i, $dbName := .Values.migrations.databases }}
+{{- range $i, $dbName := .Values.migrations.db.databases }}
 ---
 apiVersion: batch/v1
 kind: Job
@@ -14,7 +14,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: migrate
-          image: {{ $.Values.migrations.image }}
+          image: {{ $.Values.migrations.db.image }}
           imagePullPolicy: {{ $.Values.global.imagePullPolicy }}
           args:
             - >-

--- a/charts/lamassu/values.yaml
+++ b/charts/lamassu/values.yaml
@@ -132,11 +132,17 @@ services:
 toolbox:
   image: ghcr.io/lamassuiot/toolbox:2.2.0
 migrations:
-  image: ghcr.io/lamassuiot/lamassu-lamassu-db-migration:3.7.0
-  databases:
-    - alerts
-    - ca
-    - va
-    - devicemanager
-    - dmsmanager
-    - kms
+  db:
+    image: ghcr.io/lamassuiot/lamassu-lamassu-db-migration:3.7.0
+    databases:
+      - alerts
+      - ca
+      - va
+      - devicemanager
+      - dmsmanager
+      - kms
+  caToKms:
+    # -- Enable the CA-to-KMS key migration pre-upgrade hook. Only needed when upgrading from a version prior to 3.7.0.
+    enabled: false
+    # -- Docker image for the CA-to-KMS migration tool
+    image: ghcr.io/lamassuiot/lamassu-ca-to-kms-migration:3.7.0


### PR DESCRIPTION
This PR adds a Helm **pre-upgrade hook** to automatically migrate CA keys to the new KMS database schema during upgrades from versions prior to **3.7.0**. The migration is idempotent and safe to run multiple times.

Closes #73

### New Files
- **`charts/lamassu/templates/ca-to-kms-migration-job.yaml`**
  - Pre-upgrade hook Job that runs the CA-to-KMS migration tool
  - Uses KMS ConfigMap (database credentials)
  - Only enabled when `migrations.caToKms.enabled=true`

### Modified Files
- **`charts/lamassu/values.yaml`**
  - Restructured `migrations` section for clarity:
    - `migrations.db`: database migration config (image, databases)
    - `migrations.caToKms`: CA-to-KMS migration config (enabled, image)

- **`charts/lamassu/templates/migration-job.yaml`**
  - Updated paths to use new nested structure: `migrations.db.image`, `migrations.db.databases`

### Configuration

Enable for a specific upgrade:
```bash
helm upgrade lamassu ./charts/lamassu \
  --set migrations.caToKms.enabled=true