### PR TITLE
fix: upgrade fast-lane third-party images (PostgreSQL, RabbitMQ, Keycloak)

### DIFF
--- a/.github/ci/keycloak.yaml
+++ b/.github/ci/keycloak.yaml
@@ -1,46 +1,40 @@
-# Intended for helm version 25.2.0
+# Intended for helm version 0.21.9
 image:
   registry: docker.io
-  repository: bitnamilegacy/keycloak
-  tag: 26.3.3-debian-12-r0
+  repository: keycloak/keycloak
+  tag: "26.6.2"
 
-global:
-  security:
-    allowInsecureImages: true
+service:
+  httpPort: 80
 
-auth: 
+keycloak: 
   adminUser: "admin"
   adminPassword: "admin"
+  httpRelativePath: /auth
+  proxyHeaders: xforwarded
 
-postgresql:
+postgres:
   enabled: false
 
-externalDatabase:
+database:
+  type: postgres
   host: "postgresql"
-  port: 5432
-  user: "admin"
+  port: "5432"
+  username: "admin"
   password: "admin"
-  database: auth
+  name: auth
 
-logging:
-  level: INFO
-
-#extraVolumes:
-#  - name: extensions
-#    emptyDir: {}
-
-#extraVolumeMounts: 
-#  - name: extensions
-#    mountPath: /opt/bitnami/keycloak/providers
-
-
-initContainers:
+extraInitContainers:
   - name: init-custom-theme
     image: curlimages/curl:8.10.1
-    command: ['sh', '-c', 'curl -L -f -S -o /opt/bitnami/keycloak/providers/lamassu-theme.jar https://github.com/lamassuiot/keycloak-theme/releases/download/1.0.0/keycloak-theme-for-kc-22-and-above.jar']
+    command:
+    - 'sh'
+    - '-c'
+    - |
+      curl -L -f -o /opt/keycloak/providers/lamassu-theme.jar https://github.com/lamassuiot/keycloak-theme/releases/download/3.0.0/lamassu-theme.jar
     volumeMounts:
-      - name: empty-dir
-        mountPath: /opt/bitnami/keycloak/providers
+    - mountPath: "/opt/keycloak/providers"
+      name: keycloak-providers
 
 httpRelativePath: /auth/
 proxy: reencrypt
@@ -51,43 +45,53 @@ extraEnvVars:
     value: "false"
   - name: KC_HEALTH_ENABLED
     value: "true"
+  - name: KC_SPI_X509CERT_LOOKUP_PROVIDER
+    value: "envoy"
   - name: HTTP_ADDRESS_FORWARDING
     value: "true"
-  - name: QUARKUS_HTTP_ACCESS_LOG_ENABLED
+  - name: KC_HTTP_ACCESS_LOG_ENABLED
     value: "true"
-  - name: QUARKUS_HTTP_ACCESS_LOG_PATTERN
-    value: "%r\n%{ALL_REQUEST_HEADERS}"
+  - name: KC_HTTP_ACCESS_LOG_PATTERN
+    value: combined
 
-keycloakConfigCli:
-  enabled: true
-  image:
-    registry: docker.io
-    repository: bitnamilegacy/keycloak-config-cli
-    tag: 6.4.0-debian-12-r11
-  configuration:
-    realm-configuration.yaml: |
-      realm: lamassu
-      enabled: true
-      roles:
-        realm:
-        - name: pki-admin
-          description: "PKI Full Access"
-      users:
-      - username: lamassu
-        enabled: true
-        credentials:
-        - type: password
-          value: lamassu
-          temporary: true
-        requiredActions:
-        - UPDATE_PASSWORD
-        realmRoles:
-        - pki-admin
-      clients:
-      - clientId: frontend
-        enabled: true
-        redirectUris: 
-        - "/*"
-        webOrigins:
-        - "/*"
-        publicClient: true
+realm:
+  import: true
+  configFile: |
+    {
+      "realm": "lamassu",
+      "enabled": true,
+      "loginTheme": "lamassu-theme-v3",
+      "roles": {
+        "realm": [
+          {
+            "name": "pki-admin",
+            "description": "PKI Full Access"
+          }
+        ]
+      },
+      "users": [
+        {
+          "username": "lamassu",
+          "enabled": true,
+          "credentials": [
+            {
+              "type": "password",
+              "value": "lamassu",
+              "temporary": true
+            }
+          ],
+          "requiredActions": ["UPDATE_PASSWORD"],
+          "realmRoles": ["pki-admin"]
+        }
+      ],
+      "clients": [
+        {
+          "clientId": "frontend",
+          "enabled": true,
+          "redirectUris": ["/*"],
+          "webOrigins": ["/*"],
+          "publicClient": true,
+          "directAccessGrantsEnabled": true
+        }
+      ]
+    }

--- a/.github/ci/keycloak.yaml
+++ b/.github/ci/keycloak.yaml
@@ -36,10 +36,6 @@ extraInitContainers:
     - mountPath: "/opt/keycloak/providers"
       name: keycloak-providers
 
-httpRelativePath: /auth/
-proxy: reencrypt
-proxyHeaders: xforwarded
-
 extraEnvVars:
   - name: KC_HOSTNAME_STRICT
     value: "false"
@@ -47,8 +43,6 @@ extraEnvVars:
     value: "true"
   - name: KC_SPI_X509CERT_LOOKUP_PROVIDER
     value: "envoy"
-  - name: HTTP_ADDRESS_FORWARDING
-    value: "true"
   - name: KC_HTTP_ACCESS_LOG_ENABLED
     value: "true"
   - name: KC_HTTP_ACCESS_LOG_PATTERN

--- a/.github/ci/postgres.yaml
+++ b/.github/ci/postgres.yaml
@@ -1,27 +1,23 @@
-# Intended for helm version 16.7.27
+# Intended for helm version 0.19.5
 fullnameOverride: "postgresql"
 image:
   registry: docker.io
-  repository: bitnamilegacy/postgresql
-  tag: 17.6.0-debian-12-r4
+  repository: postgres
+  tag: "18.4"
 
-global:
-  security:
-    allowInsecureImages: true
-  postgresql:
-    auth:
-      username: admin
-      password: admin
+auth:
+  username: admin
+  password: admin
 
-primary:
-  initdb:
-    scripts:
-      init.sql: |
-        CREATE DATABASE auth;
-        CREATE DATABASE alerts;
-        CREATE DATABASE ca;
-        CREATE DATABASE va;
-        CREATE DATABASE cloudproxy;
-        CREATE DATABASE devicemanager;
-        CREATE DATABASE dmsmanager;
-        CREATE DATABASE kms;
+
+initdb:
+  scripts:
+    init.sql: |
+      CREATE DATABASE auth;
+      CREATE DATABASE alerts;
+      CREATE DATABASE ca;
+      CREATE DATABASE va;
+      CREATE DATABASE cloudproxy;
+      CREATE DATABASE devicemanager;
+      CREATE DATABASE dmsmanager;
+      CREATE DATABASE kms;

--- a/.github/ci/rabbitmq.yaml
+++ b/.github/ci/rabbitmq.yaml
@@ -1,14 +1,10 @@
-# Intended for helm version 16.0.14
+# Intended for helm version 0.21.4
 fullnameOverride: "rabbitmq"
-
-global:
-  security:
-    allowInsecureImages: true
     
 image:
   registry: docker.io
-  repository: bitnamilegacy/rabbitmq
-  tag: 4.1.3-debian-12-r1
+  repository: rabbitmq
+  tag: "4.3.0"
 
 auth:
   username: admin

--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -60,6 +60,7 @@ jobs:
             spec:
               controllerName: gateway.envoyproxy.io/gatewayclass-controller
           EOF
+          kubectl wait --timeout=5m -n envoy-gateway-system deployment/envoy-gateway --for=condition=Available
                 
           kubectl create namespace lamassu-test
           helm install postgres oci://registry-1.docker.io/cloudpirates/postgres --version 0.19.5 -n lamassu-test -f .github/ci/postgres.yaml --wait

--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -50,10 +50,8 @@ jobs:
       - name: Prepare kind cluster
         if: steps.list-changed.outputs.changed == 'true'
         run: |
-          kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.3/cert-manager.yaml
-          helm repo add bitnami https://charts.bitnami.com/bitnami
-          helm repo update
-          helm install eg oci://docker.io/envoyproxy/gateway-helm --version v1.3.0 -n envoy-gateway-system --create-namespace -f .github/ci/eg.yaml --wait
+          kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.20.2/cert-manager.yaml
+          helm install eg oci://docker.io/envoyproxy/gateway-helm --version v1.8.0 -n envoy-gateway-system --create-namespace -f .github/ci/eg.yaml --wait
           cat <<EOF | kubectl apply -f -
             apiVersion: gateway.networking.k8s.io/v1
             kind: GatewayClass
@@ -64,9 +62,9 @@ jobs:
           EOF
                 
           kubectl create namespace lamassu-test
-          helm install postgres bitnami/postgresql --version 16.7.27 -n lamassu-test -f .github/ci/postgres.yaml --wait
-          helm install auth bitnami/keycloak --version 25.2.0 -n lamassu-test -f .github/ci/keycloak.yaml --wait
-          helm install rabbitmq bitnami/rabbitmq --version 12.6.0 -n lamassu-test -f .github/ci/rabbitmq.yaml --wait
+          helm install postgres oci://registry-1.docker.io/cloudpirates/postgres --version 0.19.5 -n lamassu-test -f .github/ci/postgres.yaml --wait
+          helm install auth oci://registry-1.docker.io/cloudpirates/keycloak --version 0.21.9 -n lamassu-test -f .github/ci/keycloak.yaml --wait
+          helm install rabbitmq oci://registry-1.docker.io/cloudpirates/rabbitmq --version 0.21.4 -n lamassu-test -f .github/ci/rabbitmq.yaml --wait
 
       - name: Run chart-testing (install)
         if: steps.list-changed.outputs.changed == 'true'

--- a/.github/workflows/test-chart.yaml
+++ b/.github/workflows/test-chart.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Prepare kind cluster
         if: steps.list-changed.outputs.changed == 'true'
         run: |
-          kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.20.2/cert-manager.yaml
+          kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.20.2/cert-manager.yaml --wait
           helm install eg oci://docker.io/envoyproxy/gateway-helm --version v1.8.0 -n envoy-gateway-system --create-namespace -f .github/ci/eg.yaml --wait
           cat <<EOF | kubectl apply -f -
             apiVersion: gateway.networking.k8s.io/v1

--- a/.github/workflows/test-fast-lane.yaml
+++ b/.github/workflows/test-fast-lane.yaml
@@ -25,7 +25,19 @@ jobs:
           config: .github/ci/kind.yaml
       - name: Prepare kind cluster
         run: |
-          kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.14.3/cert-manager.yaml
+          kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.20.2/cert-manager.yaml --wait
+          helm install eg oci://docker.io/envoyproxy/gateway-helm --version v1.8.0 -n envoy-gateway-system --create-namespace -f .github/ci/eg.yaml --wait
+          cat <<EOF | kubectl apply -f -
+            apiVersion: gateway.networking.k8s.io/v1
+            kind: GatewayClass
+            metadata:
+              name: eg
+            spec:
+              controllerName: gateway.envoyproxy.io/gatewayclass-controller
+          EOF
+          kubectl wait --timeout=5m -n envoy-gateway-system deployment/envoy-gateway --for=condition=Available
+                
+          kubectl create namespace lamassu-ci
       - name: Run fast lane
         run: |
           ./scripts/lamassu-fast-lane.sh -n -ns lamassu-ci -d ci.lamassu.io -l ./charts/lamassu

--- a/charts/lamassu/templates/envoy-gateway.yml
+++ b/charts/lamassu/templates/envoy-gateway.yml
@@ -51,7 +51,7 @@ spec:
     kind: Gateway
     name: eg
   tls:
-    maxVersion: "1.2"
+    maxVersion: "1.3"
     # we are not adding clientValidation for the following reasons:
     # 1. it is required defining a set of trusted CA certificates to be used for client certificate validation
     # 2. in the TLS handshake, the server sends a CertificateRequest message setting the CA's Distinguished Names field, limiting to some HTTPS clients what certs can be sent

--- a/scripts/lamassu-fast-lane.sh
+++ b/scripts/lamassu-fast-lane.sh
@@ -450,122 +450,121 @@ function install_keycloak() {
     cat >keycloak.yaml <<"EOF"
 image:
   registry: docker.io
-  repository: bitnamilegacy/keycloak
-  tag: 25.0.2-debian-12-r1
+  repository: keycloak/keycloak
+  tag: "26.6"
 
-auth:
+service:
+  httpPort: 80
+
+keycloak:
   adminUser: ""
   adminPassword: ""
+  httpRelativePath: /auth
+  proxyHeaders: xforwarded
 
-postgresql:
+database:
+  type: postgres
+  host: "postgresql"
+  port: "5432"
+  name: "auth"
+  username: ""
+  password: ""
+
+postgres:
   enabled: false
 
-externalDatabase:
-  host: "postgresql"
-  port: 5432
-  user: ""
-  password: ""
-  database: auth
-
-logging:
-  level: INFO
-
-httpRelativePath: /auth/
-proxy: reencrypt
-proxyHeaders: xforwarded
+mariadb:
+  enabled: false
 
 extraEnvVars:
   - name: KC_HOSTNAME_STRICT
     value: "false"
   - name: KC_HEALTH_ENABLED
     value: "true"
-  - name: KC_LEGACY_OBSERVABILITY_INTERFACE
-    value: "true"
   - name: HTTP_ADDRESS_FORWARDING
     value: "true"
-  - name: QUARKUS_HTTP_ACCESS_LOG_ENABLED
+  - name: KC_HTTP_ACCESS_LOG_ENABLED
     value: "true"
-  - name: QUARKUS_HTTP_ACCESS_LOG_PATTERN
-    value: "%r\n%{ALL_REQUEST_HEADERS}"
+  - name: KC_HTTP_ACCESS_LOG_PATTERN
+    value: combined
 
-keycloakConfigCli:
-  enabled: true
-  image:
-    registry: docker.io
-    repository: bitnamilegacy/keycloak-config-cli
-    tag: 6.1.6-debian-12-r0
-  configuration:
-    realm-configuration.yaml: |
-      realm: lamassu
-      enabled: true
-      loginTheme: keycloakify-starter
-      roles:
-        realm:
-        - name: pki-admin
-          description: "PKI Full Access"
-      users:
-      - username: lamassu
-        enabled: true
-        credentials:
-        - type: password
-          value: lamassu
-          temporary: true
-        requiredActions:
-        - UPDATE_PASSWORD
-        realmRoles:
-        - pki-admin
-      clients:
-      - clientId: frontend
-        enabled: true
-        redirectUris:
-        - "/*"
-        webOrigins:
-        - "/*"
-        publicClient: true
-        directAccessGrantsEnabled: true
+realm:
+  import: true
+  configFile: |
+    {
+      "realm": "lamassu",
+      "enabled": true,
+      "loginTheme": "lamassu-theme-v3",
+      "roles": {
+        "realm": [
+          {
+            "name": "pki-admin",
+            "description": "PKI Full Access"
+          }
+        ]
+      },
+      "users": [
+        {
+          "username": "lamassu",
+          "enabled": true,
+          "credentials": [
+            {
+              "type": "password",
+              "value": "lamassu",
+              "temporary": true
+            }
+          ],
+          "requiredActions": ["UPDATE_PASSWORD"],
+          "realmRoles": ["pki-admin"]
+        }
+      ],
+      "clients": [
+        {
+          "clientId": "frontend",
+          "enabled": true,
+          "redirectUris": ["/*"],
+          "webOrigins": ["/*"],
+          "publicClient": true,
+          "directAccessGrantsEnabled": true
+        }
+      ]
+    }
 EOF
 
     if [ "$OFFLINE" = false ]; then
         cat >>keycloak.yaml <<"EOF"
-extraVolumes:
-  - name: extensions
-    emptyDir: {}
-
-extraVolumeMounts: 
-  - name: extensions
-    mountPath: /opt/bitnami/keycloak/providers
-
-initContainers:
+extraInitContainers:
 - name: init-custom-theme
   image: curlimages/curl:8.10.1
-  command: ['sh', '-c', 'curl -L -f -S -o /extensions/lamassu-theme.jar https://github.com/lamassuiot/keycloak-theme/releases/download/2.0.0/keycloak-theme-for-kc-22-to-25.jar']
-  volumeMounts:  
-  - mountPath: "/extensions"
-    name: extensions
+  command:
+  - 'sh'
+  - '-c'
+  - |
+    curl -L -f -o /opt/keycloak/providers/lamassu-theme.jar https://github.com/lamassuiot/keycloak-theme/releases/download/3.0.0/lamassu-theme.jar
+  volumeMounts:
+  - mountPath: "/opt/keycloak/providers"
+    name: keycloak-providers
 EOF
     fi
 
 
     export POSTGRES_USER=$POSTGRES_USER
     export POSTGRES_PWD=$POSTGRES_PWD
-    yq -i '.externalDatabase.user = env(POSTGRES_USER)' keycloak.yaml
-    yq -i '.externalDatabase.password = env(POSTGRES_PWD)' keycloak.yaml
+    yq -i '.database.username = env(POSTGRES_USER)' keycloak.yaml
+    yq -i '.database.password = env(POSTGRES_PWD)' keycloak.yaml
 
     export KEYCLOAK_USER=$KEYCLOAK_USER
     export KEYCLOAK_PWD=$KEYCLOAK_PWD
-    yq -i '.auth.adminUser = env(KEYCLOAK_USER)' keycloak.yaml
-    yq -i '.auth.adminPassword = env(KEYCLOAK_PWD)' keycloak.yaml
+    yq -i '.keycloak.adminUser = env(KEYCLOAK_USER)' keycloak.yaml
+    yq -i '.keycloak.adminPassword = env(KEYCLOAK_PWD)' keycloak.yaml
 
 
-    helm_path=bitnami/keycloak
-    if [ "$OFFLINE" = false ]; then
-        $kube $helm repo add bitnami https://charts.bitnami.com/bitnami
-        $kube $helm repo update
-    else
+    helm_path=oci://registry-1.docker.io/cloudpirates/keycloak
+    if [ "$OFFLINE" = true ]; then
         helm_path=$OFFLINE_HELMCHART_KEYCLOAK
     fi
 
-    $kube $helm install auth $helm_path --version 22.1.1 -n $NAMESPACE --wait -f keycloak.yaml
+    $kube $helm install auth $helm_path --version 0.21.9 -n $NAMESPACE --wait -f keycloak.yaml
     if [ $? -eq 0 ]; then
         echo -e "\n${GREEN}Keycloak installed${NOCOLOR}"
     else
@@ -609,6 +608,7 @@ EOF
     helm_path=bitnami/postgresql
     if [ "$OFFLINE" = false ]; then
         $kube $helm repo add bitnami https://charts.bitnami.com/bitnami
+        $kube $helm repo update
     else
         helm_path=$OFFLINE_HELMCHART_POSTGRES
     fi
@@ -704,7 +704,7 @@ function request_keycloak_user() {
     echo -n "Keycloak admin user ($KEYCLOAK_USER): "
     read req
     if [ "$req" != "" ]; then
-        RABBIT_USER=$req
+        KEYCLOAK_USER=$req
     fi
 }
 
@@ -712,7 +712,7 @@ function request_keycloak_pwd() {
     echo -n "Keycloak admin password ($KEYCLOAK_PWD): "
     read req
     if [ "$req" != "" ]; then
-        RABBIT_PWD=$req
+        KEYCLOAK_PWD=$req
     fi
 }
 
@@ -761,6 +761,67 @@ function check_dependencies() {
         check_microk8s_minimum_requirements
     fi
 
+    if [ $dist == "kind" ]; then
+        exit_if_command_not_installed $kubectl
+        exit_if_command_not_installed $helm
+        fix_kind_dns
+        check_kind_minimum_requirements
+    fi
+
+}
+
+function check_kind_minimum_requirements() {
+    # Gateway API CRDs (required by Envoy Gateway and Lamassu chart)
+    if ! $kubectl get crd gateways.gateway.networking.k8s.io &>/dev/null; then
+        echo -e "${ORANGE}Gateway API CRDs not found. Installing...${NOCOLOR}"
+        $kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml
+        if [ $? -eq 0 ]; then
+            echo -e "${GREEN}Gateway API CRDs installed${NOCOLOR}"
+        else
+            echo -e "${RED}Failed to install Gateway API CRDs${NOCOLOR}"
+            exit 1
+        fi
+    else
+        echo -e "${GREEN}✅ Gateway API CRDs already installed${NOCOLOR}"
+    fi
+
+    # cert-manager (required for Certificate and Issuer resources)
+    if ! $kubectl get ns cert-manager &>/dev/null; then
+        echo -e "${ORANGE}cert-manager not found. Installing...${NOCOLOR}"
+        $helm repo add jetstack https://charts.jetstack.io
+        $helm repo update jetstack
+        $helm install cert-manager jetstack/cert-manager \
+            --namespace cert-manager \
+            --create-namespace \
+            --set crds.enabled=true \
+            --wait
+        if [ $? -eq 0 ]; then
+            echo -e "${GREEN}cert-manager installed${NOCOLOR}"
+        else
+            echo -e "${RED}Failed to install cert-manager${NOCOLOR}"
+            exit 1
+        fi
+    else
+        echo -e "${GREEN}✅ cert-manager already installed${NOCOLOR}"
+    fi
+
+    # Envoy Gateway (HTTPRoute, GatewayClass, ClientTrafficPolicy, etc.)
+    check_envoy_gateway_helm
+}
+
+function fix_kind_dns() {
+    echo -e "${ORANGE}Kind detected: patching CoreDNS to use 8.8.8.8...${NOCOLOR}"
+    $kubectl -n kube-system get configmap coredns -o json \
+      | sed 's|forward . /etc/resolv.conf|forward . 8.8.8.8 8.8.4.4|' \
+      | $kubectl apply -f -
+    $kubectl -n kube-system rollout restart deployment coredns
+    $kubectl -n kube-system rollout status deployment coredns --timeout=60s
+    if [ $? -eq 0 ]; then
+        echo -e "${GREEN}CoreDNS patched successfully${NOCOLOR}"
+    else
+        echo -e "${RED}Failed to patch CoreDNS${NOCOLOR}"
+        exit 1
+    fi
 }
 
 function check_microk8s_minimum_requirements() {

--- a/scripts/lamassu-fast-lane.sh
+++ b/scripts/lamassu-fast-lane.sh
@@ -578,42 +578,35 @@ function install_postgresql() {
 fullnameOverride: "postgresql"
 image:
   registry: docker.io
-  repository: bitnamilegacy/postgresql
-global:
-  security:
-    allowInsecureImages: true
-  postgresql:
-    auth:
-      username: ""
-      password: ""
-primary:
-  initdb:
-    scripts:
-      init.sql: |
-        CREATE DATABASE auth;
-        CREATE DATABASE alerts;
-        CREATE DATABASE ca;
-        CREATE DATABASE va;
-        CREATE DATABASE cloudproxy;
-        CREATE DATABASE devicemanager;
-        CREATE DATABASE dmsmanager;
-        CREATE DATABASE kms;
+  repository: postgres
+  tag: "18.4"
+auth:
+  username: ""
+  password: ""
+initdb:
+  scripts:
+    init.sql: |
+      CREATE DATABASE auth;
+      CREATE DATABASE alerts;
+      CREATE DATABASE ca;
+      CREATE DATABASE va;
+      CREATE DATABASE cloudproxy;
+      CREATE DATABASE devicemanager;
+      CREATE DATABASE dmsmanager;
+      CREATE DATABASE kms;
 EOF
 
     export POSTGRES_USER=$POSTGRES_USER
     export POSTGRES_PWD=$POSTGRES_PWD
-    yq -i '.global.postgresql.auth.username = env(POSTGRES_USER)' postgres.yaml
-    yq -i '.global.postgresql.auth.password = env(POSTGRES_PWD)' postgres.yaml
+    yq -i '.auth.username = env(POSTGRES_USER)' postgres.yaml
+    yq -i '.auth.password = env(POSTGRES_PWD)' postgres.yaml
 
-    helm_path=bitnami/postgresql
-    if [ "$OFFLINE" = false ]; then
-        $kube $helm repo add bitnami https://charts.bitnami.com/bitnami
-        $kube $helm repo update
-    else
+    helm_path=oci://registry-1.docker.io/cloudpirates/postgres
+    if [ "$OFFLINE" = true ]; then
         helm_path=$OFFLINE_HELMCHART_POSTGRES
     fi
 
-    $kube $helm install postgres $helm_path -n $NAMESPACE --version 16.7.27 -f postgres.yaml --wait
+    $kube $helm install postgres $helm_path -n $NAMESPACE --version 0.19.5 -f postgres.yaml --wait
     if [ $? -eq 0 ]; then
         echo -e "\n${GREEN}PostgreSQL installed${NOCOLOR}"
     else

--- a/scripts/lamassu-fast-lane.sh
+++ b/scripts/lamassu-fast-lane.sh
@@ -750,67 +750,6 @@ function check_dependencies() {
         check_microk8s_minimum_requirements
     fi
 
-    if [ $dist == "kind" ]; then
-        exit_if_command_not_installed $kubectl
-        exit_if_command_not_installed $helm
-        fix_kind_dns
-        check_kind_minimum_requirements
-    fi
-
-}
-
-function check_kind_minimum_requirements() {
-    # Gateway API CRDs (required by Envoy Gateway and Lamassu chart)
-    if ! $kubectl get crd gateways.gateway.networking.k8s.io &>/dev/null; then
-        echo -e "${ORANGE}Gateway API CRDs not found. Installing...${NOCOLOR}"
-        $kubectl apply -f https://github.com/kubernetes-sigs/gateway-api/releases/download/v1.2.1/standard-install.yaml
-        if [ $? -eq 0 ]; then
-            echo -e "${GREEN}Gateway API CRDs installed${NOCOLOR}"
-        else
-            echo -e "${RED}Failed to install Gateway API CRDs${NOCOLOR}"
-            exit 1
-        fi
-    else
-        echo -e "${GREEN}✅ Gateway API CRDs already installed${NOCOLOR}"
-    fi
-
-    # cert-manager (required for Certificate and Issuer resources)
-    if ! $kubectl get ns cert-manager &>/dev/null; then
-        echo -e "${ORANGE}cert-manager not found. Installing...${NOCOLOR}"
-        $helm repo add jetstack https://charts.jetstack.io
-        $helm repo update jetstack
-        $helm install cert-manager jetstack/cert-manager \
-            --namespace cert-manager \
-            --create-namespace \
-            --set crds.enabled=true \
-            --wait
-        if [ $? -eq 0 ]; then
-            echo -e "${GREEN}cert-manager installed${NOCOLOR}"
-        else
-            echo -e "${RED}Failed to install cert-manager${NOCOLOR}"
-            exit 1
-        fi
-    else
-        echo -e "${GREEN}✅ cert-manager already installed${NOCOLOR}"
-    fi
-
-    # Envoy Gateway (HTTPRoute, GatewayClass, ClientTrafficPolicy, etc.)
-    check_envoy_gateway_helm
-}
-
-function fix_kind_dns() {
-    echo -e "${ORANGE}Kind detected: patching CoreDNS to use 8.8.8.8...${NOCOLOR}"
-    $kubectl -n kube-system get configmap coredns -o json \
-      | sed 's|forward . /etc/resolv.conf|forward . 8.8.8.8 8.8.4.4|' \
-      | $kubectl apply -f -
-    $kubectl -n kube-system rollout restart deployment coredns
-    $kubectl -n kube-system rollout status deployment coredns --timeout=60s
-    if [ $? -eq 0 ]; then
-        echo -e "${GREEN}CoreDNS patched successfully${NOCOLOR}"
-    else
-        echo -e "${RED}Failed to patch CoreDNS${NOCOLOR}"
-        exit 1
-    fi
 }
 
 function check_microk8s_minimum_requirements() {

--- a/scripts/lamassu-fast-lane.sh
+++ b/scripts/lamassu-fast-lane.sh
@@ -407,24 +407,13 @@ EOF
 }
 
 function install_rabbitmq() {
-    helm_path=bitnami/rabbitmq
-    if [ "$OFFLINE" = false ]; then
-        $kube $helm repo add bitnami https://charts.bitnami.com/bitnami
-        $kube $helm repo update
-    else
-        helm_path=$OFFLINE_HELMCHART_RABBITMQ
-    fi
     cat >rabbitmq.yaml <<"EOF"
 fullnameOverride: "rabbitmq"
 
-global:
-  security:
-    allowInsecureImages: true
-
 image:
   registry: docker.io
-  repository: bitnamilegacy/rabbitmq
-  #tag: 4.1.3-debian-12-r1
+  repository: rabbitmq
+  tag: "4.3.0"
 
 auth:
   username:
@@ -436,8 +425,13 @@ EOF
 
    yq -i '.auth.username = env(RABBIT_USER)' rabbitmq.yaml
    yq -i '.auth.password = env(RABBIT_PWD)' rabbitmq.yaml
+
+    helm_path=oci://registry-1.docker.io/cloudpirates/rabbitmq
+    if [ "$OFFLINE" = true ]; then
+        helm_path=$OFFLINE_HELMCHART_RABBITMQ
+    fi
    
-   $kube $helm install rabbitmq $helm_path --version 12.6.0 -n $NAMESPACE -f rabbitmq.yaml --wait
+   $kube $helm install rabbitmq $helm_path --version 0.21.4 -n $NAMESPACE -f rabbitmq.yaml --wait
     if [ $? -eq 0 ]; then
         echo -e "\n${GREEN}RabbitMQ installed${NOCOLOR}"
     else
@@ -451,7 +445,7 @@ function install_keycloak() {
 image:
   registry: docker.io
   repository: keycloak/keycloak
-  tag: "26.6"
+  tag: "26.6.2"
 
 service:
   httpPort: 80
@@ -481,6 +475,8 @@ extraEnvVars:
     value: "false"
   - name: KC_HEALTH_ENABLED
     value: "true"
+  - name: KC_SPI_X509CERT_LOOKUP_PROVIDER
+    value: "envoy"
   - name: HTTP_ADDRESS_FORWARDING
     value: "true"
   - name: KC_HTTP_ACCESS_LOG_ENABLED


### PR DESCRIPTION
## Summary

Migrates the `lamassu-fast-lane.sh` script away from `bitnamilegacy` images to address [CVE-2025-6965](https://www.cve.org/CVERecord?id=CVE-2025-6965) detected in the `bitnamilegacy/postgresql` image.

All three third-party dependencies are now sourced from the [CloudPirates Helm charts](https://github.com/CloudPirates-io/helm-charts), which ship official upstream images.

## Changes

### PostgreSQL
- Migrated from `bitnami/postgresql` (bitnamilegacy image) to `oci://registry-1.docker.io/cloudpirates/postgres` v0.19.5
- Switched to official `postgres:18.4` image
- Simplified values structure (`auth.*`, `initdb.scripts`)

### RabbitMQ
- Migrated from `bitnami/rabbitmq` to `oci://registry-1.docker.io/cloudpirates/rabbitmq` v0.21.4
- Switched to official `rabbitmq:4.3.0` image
- Removed `allowInsecureImages` workaround

### Keycloak
- Migrated from `bitnami/keycloak` to `oci://registry-1.docker.io/cloudpirates/keycloak` v0.21.9
- Updated to `keycloak/keycloak:26.6.2`
- Updated theme to `lamassu-theme-v3`
- Migrated to new chart values structure (`keycloak.*`, `database.*`, `realm.*`)
- Added `KC_SPI_X509CERT_LOOKUP_PROVIDER: envoy` for mTLS via Envoy Gateway
- Removed `keycloak-config-cli` dependency (realm import now native)

### Envoy Gateway
- Bumped `ClientTrafficPolicy` `maxVersion` from `1.2` to `1.3`

### CI
- Updated `test-chart.yaml` kind cluster dependencies to match new chart versions
- Fixed cert-manager and Envoy Gateway readiness waits

## Relation to PR #71

This PR supersedes [#71](https://github.com/lamassuiot/lamassu-helm/pull/71) (`cloudp` branch), which addressed the same migration. This branch builds on that work with:
- Newer chart versions (postgres `0.19.5`, rabbitmq `0.21.4`, keycloak `0.21.9` vs `0.19.0`/`0.20.0`/`0.20.0`)
- Newer image tags (Keycloak `26.6.2` vs `26.6.0`, PostgreSQL `18.4`)
- Explicit image pins for PostgreSQL and RabbitMQ
- Updated Keycloak theme (`lamassu-theme-v3`)
- Additional Keycloak env vars (`KC_SPI_X509CERT_LOOKUP_PROVIDER`)
- Keycloak service port aligned to `80` (no downstream reference changes needed)

Closes #74