### PR TITLE
fix: release workflow: fix wrong yq path for migrations images

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -73,7 +73,8 @@ jobs:
           yq eval '.services.dmsManager.image = "ghcr.io/lamassuiot/lamassu-dmsmanager:${{ github.event.inputs.app_version }}"' -i charts/${{ github.event.inputs.chart_to_release }}/values.yaml
           yq eval '.services.alerts.image = "ghcr.io/lamassuiot/lamassu-alerts:${{ github.event.inputs.app_version }}"' -i charts/${{ github.event.inputs.chart_to_release }}/values.yaml
           yq eval '.services.kms.image = "ghcr.io/lamassuiot/lamassu-kms:${{ github.event.inputs.app_version }}"' -i charts/${{ github.event.inputs.chart_to_release }}/values.yaml
-          yq eval '.migrations.image = "ghcr.io/lamassuiot/lamassu-lamassu-db-migration:${{ github.event.inputs.app_version }}"' -i charts/${{ github.event.inputs.chart_to_release }}/values.yaml
+          yq eval '.migrations.db.image = "ghcr.io/lamassuiot/lamassu-lamassu-db-migration:${{ github.event.inputs.app_version }}"' -i charts/${{ github.event.inputs.chart_to_release }}/values.yaml
+          yq eval '.migrations.caToKms.image = "ghcr.io/lamassuiot/lamassu-ca-to-kms-migration:${{ github.event.inputs.app_version }}"' -i charts/${{ github.event.inputs.chart_to_release }}/values.yaml
       
       - name: Generate charts changelog files
         shell: bash

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This table shows the relationship between Helm chart versions, application versi
 
 | Helm Chart | App Version | UI Image | Backend Images (CA/VA/DevMgr/DMS/Alerts) | KMS Image | Notes |
 |------------|-------------|----------|-------------------------------------------|-----------|-------|
+| 3.8.0 | 3.8.0 | 4.3.0 | 3.8.0 | 3.8.0 | mTLS + Webhook authentication method introduced. Full chain validation in enroll |
 | 3.7.0 | 3.7.0 | 4.2.0 | 3.7.0 | 3.7.0 | **NEW**: KMS service introduced as first-class service |
 | 3.6.1 | 3.6.1 | 4.1.1 | 3.6.1 | N/A | Latest stable release on main branch |
 | 3.6.0 | 3.6.0 | 4.1.0 | 3.6.0 | N/A | |


### PR DESCRIPTION
## Summary

Fixes two bugs in the **Update Backend docker image version** step of `.github/workflows/release.yaml`.

### Bug 1 — Wrong `yq` path for db migration image

The path `.migrations.image` does not exist in `values.yaml`. The correct path is `.migrations.db.image`, so the image tag was silently never updated on release.

### Bug 2 — Missing ca-to-kms migration image update

`.migrations.caToKms.image` was never updated by the workflow, leaving its version pinned to whatever was last committed manually.

## Changes

- `.migrations.image` → `.migrations.db.image`
- Added `yq` line to update `.migrations.caToKms.image`

Closes #76