### PR TITLE
fix: update chart image versions and correct migrations configuration

### DIFF
--- a/charts/lamassu/README.md
+++ b/charts/lamassu/README.md
@@ -52,13 +52,13 @@ PKI for Industrial IoT for Kubernetes
 | auth.authorization.rolesClaim | string | `"realm_access.roles"` | JWT claim to extract user roles from |
 | auth.authorization.roles.admin | string | `"pki-admin"` | Role for Lamassu admin users |
 | **Service Images** | | | |
-| services.ui.image | string | `"ghcr.io/lamassuiot/lamassu-ui:4.2.0"` | Docker image for UI component |
-| services.ca.image | string | `"ghcr.io/lamassuiot/lamassu-ca:3.7.0"` | Docker image for CA component |
-| services.va.image | string | `"ghcr.io/lamassuiot/lamassu-va:3.7.0"` | Docker image for VA component |
-| services.kms.image | string | `"ghcr.io/lamassuiot/lamassu-kms:3.7.0"` | Docker image for KMS component |
-| services.deviceManager.image | string | `"ghcr.io/lamassuiot/lamassu-devmanager:3.7.0"` | Docker image for Device Manager component |
-| services.dmsManager.image | string | `"ghcr.io/lamassuiot/lamassu-dmsmanager:3.7.0"` | Docker image for DMS Manager component |
-| services.alerts.image | string | `"ghcr.io/lamassuiot/lamassu-alerts:3.7.0"` | Docker image for Alerts component |
+| services.ui.image | string | `"ghcr.io/lamassuiot/lamassu-ui:4.3.0"` | Docker image for UI component |
+| services.ca.image | string | `"ghcr.io/lamassuiot/lamassu-ca:3.8.0"` | Docker image for CA component |
+| services.va.image | string | `"ghcr.io/lamassuiot/lamassu-va:3.8.0"` | Docker image for VA component |
+| services.kms.image | string | `"ghcr.io/lamassuiot/lamassu-kms:3.8.0"` | Docker image for KMS component |
+| services.deviceManager.image | string | `"ghcr.io/lamassuiot/lamassu-devmanager:3.8.0"` | Docker image for Device Manager component |
+| services.dmsManager.image | string | `"ghcr.io/lamassuiot/lamassu-dmsmanager:3.8.0"` | Docker image for DMS Manager component |
+| services.alerts.image | string | `"ghcr.io/lamassuiot/lamassu-alerts:3.8.0"` | Docker image for Alerts component |
 | **CA Service Configuration** | | | |
 | services.ca.domains | list | `["dev.lamassu.io"]` | Domains for signing/generating CAs and certificates |
 | services.ca.monitoring.frequency | string | `"* * * * *"` | CA health check frequency (CRON syntax, can include seconds) |
@@ -82,6 +82,7 @@ PKI for Industrial IoT for Kubernetes
 | services.alerts.smtp_server.insecure | bool | `false` | Skip TLS certificate verification |
 | **Toolbox & Migrations** | | | |
 | toolbox.image | string | `"ghcr.io/lamassuiot/toolbox:2.2.0"` | Docker image for toolbox utility |
-| migrations.image | string | `"ghcr.io/lamassuiot/lamassu-lamassu-db-migration:3.7.0"` | Docker image for database migrations |
-| migrations.databases | list | `["auth", "alerts", "ca", "va", "cloudproxy", "devicemanager", "dmsmanager", "kms"]` | List of databases to migrate |
+| migrations.db.image | string | `"ghcr.io/lamassuiot/lamassu-lamassu-db-migration:3.8.0"` | Docker image for database migrations |
+| migrations.db.databases | list | `["alerts", "ca", "va", "devicemanager", "dmsmanager", "kms"]` | List of databases to migrate |
+| migrations.caToKms.image | string | `"ghcr.io/lamassuiot/lamassu-ca-to-kms-migration:3.8.0"` | Docker image for the CA-to-KMS migration tool |
 

--- a/charts/lamassu/values.yaml
+++ b/charts/lamassu/values.yaml
@@ -146,4 +146,3 @@ migrations:
     enabled: false
     # -- Docker image for the CA-to-KMS migration tool
     image: ghcr.io/lamassuiot/lamassu-ca-to-kms-migration:3.8.0
-  image: ghcr.io/lamassuiot/lamassu-lamassu-db-migration:3.8.0


### PR DESCRIPTION
This pull request updates the **Lamassu** Helm chart **README** and **values** to reflect the latest **Docker image versions** (UI `4.3.0`, services `3.8.0`) and corrects the migrations configuration path to align with the actual chart structure. It removes an obsolete standalone migration image entry from **values.yaml** that was incorrectly placed at the chart root level.

### Changes

#### Documentation
- Updated all service image versions in the README values table to match current defaults: UI `4.3.0`, CA/VA/KMS/DeviceManager/DmsManager/Alerts `3.8.0`, and DB migration tool `3.8.0`
- Corrected the migrations configuration path from `migrations.image` and `migrations.databases` to `migrations.db.image` and `migrations.db.databases` to match the actual values.yaml structure
- Added documentation for `migrations.caToKms.image` (the CA-to-KMS migration tool) to the README values table

#### Configuration  
- Removed the obsolete standalone `migrations.image` entry from **values.yaml** that was placed at the root of the migrations block and duplicating the correct `migrations.db.image` path