### PR TITLE
feat: add OpenTelemetry support for observability in configmaps and scripts

### DIFF
--- a/charts/lamassu/templates/alert-configmap.yml
+++ b/charts/lamassu/templates/alert-configmap.yml
@@ -56,3 +56,20 @@ data:
       password: {{ .Values.services.alerts.smtp_server.password }}
       ssl: {{ .Values.services.alerts.smtp_server.ssl }}
       insecure: {{ .Values.services.alerts.smtp_server.insecure }}
+{{ if .Values.observability.enabled }}
+    otel:
+      traces:
+        enabled: true
+        hostname: {{ .Values.observability.traces.hostname }}
+        port: {{ .Values.observability.traces.port }}
+        scheme: {{ .Values.observability.traces.scheme }}
+        base_path: "{{ .Values.observability.traces.basePath }}"
+      logging:
+        enabled: true
+        hostname: {{ .Values.observability.logs.hostname }}
+        port: {{ .Values.observability.logs.port }}
+        scheme: {{ .Values.observability.logs.scheme }}
+        base_path: "{{ .Values.observability.logs.basePath }}"
+      metrics:
+        enabled: false
+{{ end }}

--- a/charts/lamassu/templates/aws-connector-configmap.yml
+++ b/charts/lamassu/templates/aws-connector-configmap.yml
@@ -60,6 +60,23 @@ data:
     connector_id:  {{ $instance.id }}
     aws_config:
       {{ $instance.credentials | toYaml | indent 6 | trim  }}
+{{ if $.Values.observability.enabled }}
+    otel:
+      traces:
+        enabled: true
+        hostname: {{ $.Values.observability.traces.hostname }}
+        port: {{ $.Values.observability.traces.port }}
+        scheme: {{ $.Values.observability.traces.scheme }}
+        base_path: "{{ $.Values.observability.traces.basePath }}"
+      logging:
+        enabled: true
+        hostname: {{ $.Values.observability.logs.hostname }}
+        port: {{ $.Values.observability.logs.port }}
+        scheme: {{ $.Values.observability.logs.scheme }}
+        base_path: "{{ $.Values.observability.logs.basePath }}"
+      metrics:
+        enabled: false
+{{ end }}
 ---
 {{- end -}}
 {{- end -}}

--- a/charts/lamassu/templates/ca-configmap.yml
+++ b/charts/lamassu/templates/ca-configmap.yml
@@ -54,3 +54,20 @@ data:
     {{ range $.Values.services.ca.domains }}
       - "{{ . }}/api/va"
     {{ end }}
+{{ if .Values.observability.enabled }}
+    otel:
+      traces:
+        enabled: true
+        hostname: {{ .Values.observability.traces.hostname }}
+        port: {{ .Values.observability.traces.port }}
+        scheme: {{ .Values.observability.traces.scheme }}
+        base_path: "{{ .Values.observability.traces.basePath }}"
+      logging:
+        enabled: true
+        hostname: {{ .Values.observability.logs.hostname }}
+        port: {{ .Values.observability.logs.port }}
+        scheme: {{ .Values.observability.logs.scheme }}
+        base_path: "{{ .Values.observability.logs.basePath }}"
+      metrics:
+        enabled: false
+{{ end }}

--- a/charts/lamassu/templates/device-manager-configmap.yml
+++ b/charts/lamassu/templates/device-manager-configmap.yml
@@ -73,3 +73,20 @@ data:
       protocol: http
       hostname: ca
       port: 8085
+{{ if .Values.observability.enabled }}
+    otel:
+      traces:
+        enabled: true
+        hostname: {{ .Values.observability.traces.hostname }}
+        port: {{ .Values.observability.traces.port }}
+        scheme: {{ .Values.observability.traces.scheme }}
+        base_path: "{{ .Values.observability.traces.basePath }}"
+      logging:
+        enabled: true
+        hostname: {{ .Values.observability.logs.hostname }}
+        port: {{ .Values.observability.logs.port }}
+        scheme: {{ .Values.observability.logs.scheme }}
+        base_path: "{{ .Values.observability.logs.basePath }}"
+      metrics:
+        enabled: false
+{{ end }}

--- a/charts/lamassu/templates/dms-manager-configmap.yml
+++ b/charts/lamassu/templates/dms-manager-configmap.yml
@@ -97,3 +97,20 @@ data:
       port: 8085
     
     downstream_cert_file: /shared/root.crt
+{{ if .Values.observability.enabled }}
+    otel:
+      traces:
+        enabled: true
+        hostname: {{ .Values.observability.traces.hostname }}
+        port: {{ .Values.observability.traces.port }}
+        scheme: {{ .Values.observability.traces.scheme }}
+        base_path: "{{ .Values.observability.traces.basePath }}"
+      logging:
+        enabled: true
+        hostname: {{ .Values.observability.logs.hostname }}
+        port: {{ .Values.observability.logs.port }}
+        scheme: {{ .Values.observability.logs.scheme }}
+        base_path: "{{ .Values.observability.logs.basePath }}"
+      metrics:
+        enabled: false
+{{ end }}

--- a/charts/lamassu/templates/kms-configmap.yml
+++ b/charts/lamassu/templates/kms-configmap.yml
@@ -39,5 +39,22 @@ data:
       migrate_keys_format: false
       log_level: "trace"
       default_id: {{ .Values.services.kms.cryptoEngines.defaultEngineID }}
-      engines:      
+      engines:
         {{ .Values.services.kms.cryptoEngines.engines | toYaml | indent 4 | nindent 4 | trim  }}
+{{ if .Values.observability.enabled }}
+    otel:
+      traces:
+        enabled: true
+        hostname: {{ .Values.observability.traces.hostname }}
+        port: {{ .Values.observability.traces.port }}
+        scheme: {{ .Values.observability.traces.scheme }}
+        base_path: "{{ .Values.observability.traces.basePath }}"
+      logging:
+        enabled: true
+        hostname: {{ .Values.observability.logs.hostname }}
+        port: {{ .Values.observability.logs.port }}
+        scheme: {{ .Values.observability.logs.scheme }}
+        base_path: "{{ .Values.observability.logs.basePath }}"
+      metrics:
+        enabled: false
+{{ end }}

--- a/charts/lamassu/templates/observability-httproutes.yaml
+++ b/charts/lamassu/templates/observability-httproutes.yaml
@@ -1,0 +1,142 @@
+{{ if .Values.observability.enabled }}
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: infra-logs
+  namespace: {{ .Release.Namespace }}
+spec:
+  parentRefs:
+    - name: eg
+      sectionName: https
+  rules:
+    # Redirect the bare path to a trailing slash so the VictoriaLogs vmui
+    # resolves its relative ./assets/* references correctly.
+    - matches:
+      - path:
+          type: Exact
+          value: {{ .Values.observability.routes.logs.path }}
+      filters:
+      - type: RequestRedirect
+        requestRedirect:
+          path:
+            type: ReplaceFullPath
+            replaceFullPath: {{ .Values.observability.routes.logs.path }}/
+          statusCode: 302
+    # Forward the vmui query/API calls (e.g. /select/logsql/query, /select/jaeger/*)
+    # to the backend /select/* path. This rule has a longer prefix than the UI
+    # rule below, so Gateway API longest-prefix precedence selects it for API calls.
+    - matches:
+      - path:
+          type: PathPrefix
+          value: {{ .Values.observability.routes.logs.path }}/select
+      filters:
+      - type: URLRewrite
+        urlRewrite:
+          path:
+            type: ReplacePrefixMatch
+            replacePrefixMatch: /select
+      backendRefs:
+        - name: {{ .Values.observability.routes.logs.hostname }}
+          port: {{ .Values.observability.routes.logs.port }}
+    # Serve the VictoriaLogs web UI (vmui) under the configured path.
+    - matches:
+      - path:
+          type: PathPrefix
+          value: {{ .Values.observability.routes.logs.path }}
+      filters:
+      - type: URLRewrite
+        urlRewrite:
+          path:
+            type: ReplacePrefixMatch
+            replacePrefixMatch: /select/vmui
+      backendRefs:
+        - name: {{ .Values.observability.routes.logs.hostname }}
+          port: {{ .Values.observability.routes.logs.port }}
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: infra-traces
+  namespace: {{ .Release.Namespace }}
+spec:
+  parentRefs:
+    - name: eg
+      sectionName: https
+  rules:
+    # Redirect the bare path to a trailing slash so the VictoriaTraces vmui
+    # resolves its relative ./assets/* references correctly.
+    - matches:
+      - path:
+          type: Exact
+          value: {{ .Values.observability.routes.traces.path }}
+      filters:
+      - type: RequestRedirect
+        requestRedirect:
+          path:
+            type: ReplaceFullPath
+            replaceFullPath: {{ .Values.observability.routes.traces.path }}/
+          statusCode: 302
+    # Forward the vmui query/API calls (e.g. /select/logsql/query, /select/jaeger/*)
+    # to the backend /select/* path. This rule has a longer prefix than the UI
+    # rule below, so Gateway API longest-prefix precedence selects it for API calls.
+    - matches:
+      - path:
+          type: PathPrefix
+          value: {{ .Values.observability.routes.traces.path }}/select
+      filters:
+      - type: URLRewrite
+        urlRewrite:
+          path:
+            type: ReplacePrefixMatch
+            replacePrefixMatch: /select
+      backendRefs:
+        - name: {{ .Values.observability.routes.traces.hostname }}
+          port: {{ .Values.observability.routes.traces.port }}
+    # Serve the VictoriaTraces web UI (vmui) under the configured path.
+    - matches:
+      - path:
+          type: PathPrefix
+          value: {{ .Values.observability.routes.traces.path }}
+      filters:
+      - type: URLRewrite
+        urlRewrite:
+          path:
+            type: ReplacePrefixMatch
+            replacePrefixMatch: /select/vmui
+      backendRefs:
+        - name: {{ .Values.observability.routes.traces.hostname }}
+          port: {{ .Values.observability.routes.traces.port }}
+---
+apiVersion: gateway.networking.k8s.io/v1beta1
+kind: HTTPRoute
+metadata:
+  name: infra-jaeger
+  namespace: {{ .Release.Namespace }}
+spec:
+  parentRefs:
+    - name: eg
+      sectionName: https
+  rules:
+    # Redirect the bare path to a trailing slash so the Jaeger UI computes the
+    # correct relative ./static/* references and <base href>.
+    - matches:
+      - path:
+          type: Exact
+          value: {{ .Values.observability.routes.jaeger.path }}
+      filters:
+      - type: RequestRedirect
+        requestRedirect:
+          path:
+            type: ReplaceFullPath
+            replaceFullPath: {{ .Values.observability.routes.jaeger.path }}/
+          statusCode: 302
+    # Serve the Jaeger query UI. Jaeger is configured with query base_path equal
+    # to this prefix, so no path rewrite is applied.
+    - matches:
+      - path:
+          type: PathPrefix
+          value: {{ .Values.observability.routes.jaeger.path }}
+      backendRefs:
+        - name: {{ .Values.observability.routes.jaeger.hostname }}
+          port: {{ .Values.observability.routes.jaeger.port }}
+{{ end }}

--- a/charts/lamassu/templates/va-configmap.yaml
+++ b/charts/lamassu/templates/va-configmap.yaml
@@ -86,3 +86,20 @@ data:
       protocol: "http"
       hostname: "ca"
       port: 8085
+{{ if .Values.observability.enabled }}
+    otel:
+      traces:
+        enabled: true
+        hostname: {{ .Values.observability.traces.hostname }}
+        port: {{ .Values.observability.traces.port }}
+        scheme: {{ .Values.observability.traces.scheme }}
+        base_path: "{{ .Values.observability.traces.basePath }}"
+      logging:
+        enabled: true
+        hostname: {{ .Values.observability.logs.hostname }}
+        port: {{ .Values.observability.logs.port }}
+        scheme: {{ .Values.observability.logs.scheme }}
+        base_path: "{{ .Values.observability.logs.basePath }}"
+      metrics:
+        enabled: false
+{{ end }}

--- a/charts/lamassu/values.yaml
+++ b/charts/lamassu/values.yaml
@@ -48,6 +48,50 @@ amqp:
   password: ""
   # -- Enable AMQP over TLS (aka AMPQS)
   tls: false
+observability:
+  # -- Enable OpenTelemetry instrumentation for all Lamassu services
+  enabled: false
+  # -- HTTP routes for the observability UIs exposed through the API Gateway
+  routes:
+    logs:
+      # -- Path prefix at which Victoria Logs UI is exposed through the gateway
+      path: /infra/logs
+      # -- Backend service for the Victoria Logs UI (vmui)
+      hostname: "victoria-logs"
+      # -- Backend port for the Victoria Logs UI
+      port: 9428
+    traces:
+      # -- Path prefix at which VictoriaTraces UI is exposed through the gateway
+      path: /infra/traces
+      # -- Backend service for the VictoriaTraces UI (vmui)
+      hostname: "victoria-traces"
+      # -- Backend port for the VictoriaTraces UI
+      port: 10428
+    jaeger:
+      # -- Path prefix at which the Jaeger UI is exposed through the gateway (must match the Jaeger query base_path)
+      path: /infra/jaeger
+      # -- Backend service for the Jaeger query UI
+      hostname: "jaeger"
+      # -- Backend port for the Jaeger query UI
+      port: 16686
+  traces:
+    # -- Hostname of the OTLP HTTP collector that fans out traces to Jaeger and VictoriaTraces (deployed by --otel fastlane flag)
+    hostname: "otel-collector"
+    # -- OTLP HTTP port exposed by the OTel Collector
+    port: 4318
+    # -- Scheme for the OTLP traces endpoint (http | https)
+    scheme: http
+    # -- Base path for the OTLP traces ingestion endpoint (empty = standard /v1/traces)
+    basePath: ""
+  logs:
+    # -- Hostname of the Victoria Logs OTLP HTTP endpoint (deployed by --otel fastlane flag)
+    hostname: "victoria-logs"
+    # -- OTLP HTTP port exposed by Victoria Logs
+    port: 9428
+    # -- Scheme for the Victoria Logs OTLP endpoint (http | https)
+    scheme: http
+    # -- Base path for the Victoria Logs OTLP log ingestion endpoint
+    basePath: "/insert/opentelemetry/v1/logs"
 auth:
   oidc:
     frontend:

--- a/scripts/lamassu-fast-lane.sh
+++ b/scripts/lamassu-fast-lane.sh
@@ -11,6 +11,7 @@ NAMESPACE=lamassu-dev
 NAMESPACE_OVERRIDE=false
 OFFLINE=false
 NON_INTERACTIVE=false
+OTEL=false
 HTTPS_PORT=443
 HTTP_PORT=80
 LAMASSU_CHART_PATH="lamassuiot/lamassu"
@@ -40,6 +41,10 @@ OFFLINE_HELMCHART_LAMASSU=""
 OFFLINE_HELMCHART_RABBITMQ=""
 OFFLINE_HELMCHART_KEYCLOAK=""
 OFFLINE_HELMCHART_POSTGRES=""
+OFFLINE_HELMCHART_VICTORIA_LOGS=""
+OFFLINE_HELMCHART_VICTORIA_TRACES=""
+OFFLINE_HELMCHART_JAEGER=""
+OFFLINE_HELMCHART_OTEL_COLLECTOR=""
 
 
 function main() {
@@ -71,6 +76,24 @@ function main() {
             echo -e "\n${RED}Postgres helm chart path is empty${NOCOLOR}"
             exit 1
         fi
+        if [ "$OTEL" = true ]; then
+            if [ "$OFFLINE_HELMCHART_VICTORIA_LOGS" = "" ]; then
+                echo -e "\n${RED}Victoria Logs helm chart path is empty (required with --otel and --offline)${NOCOLOR}"
+                exit 1
+            fi
+            if [ "$OFFLINE_HELMCHART_VICTORIA_TRACES" = "" ]; then
+                echo -e "\n${RED}VictoriaTraces helm chart path is empty (required with --otel and --offline)${NOCOLOR}"
+                exit 1
+            fi
+            if [ "$OFFLINE_HELMCHART_JAEGER" = "" ]; then
+                echo -e "\n${RED}Jaeger helm chart path is empty (required with --otel and --offline)${NOCOLOR}"
+                exit 1
+            fi
+            if [ "$OFFLINE_HELMCHART_OTEL_COLLECTOR" = "" ]; then
+                echo -e "\n${RED}OTel Collector helm chart path is empty (required with --otel and --offline)${NOCOLOR}"
+                exit 1
+            fi
+        fi
     else
         echo -e "${ORANGE}ONLINE MODE ENABLED${NOCOLOR}"
     fi
@@ -88,7 +111,13 @@ function main() {
     install_keycloak
     echo -e "\n${BLUE}6) Install RabbitMQ${NOCOLOR}"
     install_rabbitmq
-    echo -e "\n${BLUE}7) Install Lamassu IoT. It may take a few minutes${NOCOLOR}"
+    if [ "$OTEL" = true ]; then
+        echo -e "\n${BLUE}7) Install Observability Stack (Victoria Logs + VictoriaTraces + Jaeger + OTel Collector)${NOCOLOR}"
+        install_observability
+        echo -e "\n${BLUE}8) Install Lamassu IoT. It may take a few minutes${NOCOLOR}"
+    else
+        echo -e "\n${BLUE}7) Install Lamassu IoT. It may take a few minutes${NOCOLOR}"
+    fi
     install_lamassu
 
     final_instructions
@@ -112,6 +141,11 @@ function usage() {
     echo " --helm-chart-keycloak        (Only needed while using --offline) Path to the Keycloak helm chart (.tgz format)"
     echo " --helm-chart-rabbitmq        (Only needed while using --offline) Path to the RabbitMQ helm chart (.tgz format)"
     echo " -l, --local-chart-path       Path to the local chart folder"
+    echo " --otel                       Deploy Victoria Logs, VictoriaTraces, Jaeger & an OTel Collector (fan-out) and configure OpenTelemetry in all Lamassu services"
+    echo " --helm-chart-victoria-logs   (Only needed while using --offline with --otel) Path to the victoria-logs-single helm chart (.tgz format)"
+    echo " --helm-chart-victoria-traces (Only needed while using --offline with --otel) Path to the victoria-traces-single helm chart (.tgz format)"
+    echo " --helm-chart-jaeger          (Only needed while using --offline with --otel) Path to the Jaeger helm chart (.tgz format)"
+    echo " --helm-chart-otel-collector  (Only needed while using --offline with --otel) Path to the opentelemetry-collector helm chart (.tgz format)"
 }
 
 function has_argument() {
@@ -262,6 +296,49 @@ function process_flags() {
 
             shift
             ;;
+        --otel)
+            OTEL=true
+            ;;
+        --helm-chart-victoria-logs)
+            if ! has_argument $@; then
+                echo -e "\n${RED}Victoria Logs Helm Chart not specified.${NOCOLOR}" >&2
+                usage
+                exit 1
+            fi
+            OFFLINE_HELMCHART_VICTORIA_LOGS=$(extract_argument $@)
+
+            shift
+            ;;
+        --helm-chart-victoria-traces)
+            if ! has_argument $@; then
+                echo -e "\n${RED}VictoriaTraces Helm Chart not specified.${NOCOLOR}" >&2
+                usage
+                exit 1
+            fi
+            OFFLINE_HELMCHART_VICTORIA_TRACES=$(extract_argument $@)
+
+            shift
+            ;;
+        --helm-chart-jaeger)
+            if ! has_argument $@; then
+                echo -e "\n${RED}Jaeger Helm Chart not specified.${NOCOLOR}" >&2
+                usage
+                exit 1
+            fi
+            OFFLINE_HELMCHART_JAEGER=$(extract_argument $@)
+
+            shift
+            ;;
+        --helm-chart-otel-collector)
+            if ! has_argument $@; then
+                echo -e "\n${RED}OTel Collector Helm Chart not specified.${NOCOLOR}" >&2
+                usage
+                exit 1
+            fi
+            OFFLINE_HELMCHART_OTEL_COLLECTOR=$(extract_argument $@)
+
+            shift
+            ;;
         *)
             echo -e "\n${RED}Invalid option: $1${NOCOLOR}" >&2
             usage
@@ -373,6 +450,9 @@ fi
     yq -i '.amqp.username = (env(RABBIT_USER))' lamassu.yaml
     yq -i '.amqp.password = (env(RABBIT_PWD))' lamassu.yaml
 
+    if [ "$OTEL" = true ]; then
+        yq -i '.observability.enabled = true' lamassu.yaml
+    fi
 
     helm_path=$LAMASSU_CHART_PATH
     if [ "$OFFLINE" = false ]; then
@@ -839,6 +919,151 @@ EOF
             echo "❌ Failed to create GatewayClass 'eg'. Ensure Gateway API CRDs are installed."
             exit 1
         fi
+    fi
+}
+
+function install_observability() {
+    echo -e "${ORANGE}Installing Victoria Logs...${NOCOLOR}"
+    cat >victoria-logs.yaml <<"EOF"
+server:
+  fullnameOverride: "victoria-logs"
+  persistentVolume:
+    enabled: false
+EOF
+
+    victoria_logs_helm_path=vm/victoria-logs-single
+    if [ "$OFFLINE" = false ]; then
+        $kube $helm repo add vm https://victoriametrics.github.io/helm-charts/ 2>/dev/null || true
+        $kube $helm repo update vm 2>/dev/null || true
+    else
+        victoria_logs_helm_path=$OFFLINE_HELMCHART_VICTORIA_LOGS
+    fi
+
+    $kube $helm install victoria-logs $victoria_logs_helm_path -n $NAMESPACE -f victoria-logs.yaml --wait
+    if [ $? -eq 0 ]; then
+        echo -e "\n${GREEN}Victoria Logs installed${NOCOLOR}"
+    else
+        echo -e "\n${RED}Error installing Victoria Logs${NOCOLOR}"
+        exit 1
+    fi
+
+    echo -e "${ORANGE}Installing VictoriaTraces...${NOCOLOR}"
+    cat >victoria-traces.yaml <<"EOF"
+server:
+  fullnameOverride: "victoria-traces"
+  persistentVolume:
+    enabled: false
+EOF
+
+    victoria_traces_helm_path=vm/victoria-traces-single
+    if [ "$OFFLINE" = false ]; then
+        $kube $helm repo add vm https://victoriametrics.github.io/helm-charts/ 2>/dev/null || true
+        $kube $helm repo update vm 2>/dev/null || true
+    else
+        victoria_traces_helm_path=$OFFLINE_HELMCHART_VICTORIA_TRACES
+    fi
+
+    $kube $helm install victoria-traces $victoria_traces_helm_path -n $NAMESPACE -f victoria-traces.yaml --wait
+    if [ $? -eq 0 ]; then
+        echo -e "\n${GREEN}VictoriaTraces installed${NOCOLOR}"
+    else
+        echo -e "\n${RED}Error installing VictoriaTraces${NOCOLOR}"
+        exit 1
+    fi
+
+    echo -e "${ORANGE}Installing Jaeger...${NOCOLOR}"
+    cat >jaeger.yaml <<"EOF"
+fullnameOverride: jaeger
+userconfig:
+  service:
+    extensions: [jaeger_storage, jaeger_query, healthcheckv2]
+    pipelines:
+      traces:
+        receivers: [otlp]
+        processors: [batch]
+        exporters: [jaeger_storage_exporter]
+  extensions:
+    healthcheckv2:
+      use_v2: true
+      http:
+        endpoint: 0.0.0.0:13133
+    jaeger_query:
+      base_path: /infra/jaeger
+      storage:
+        traces: main_store
+    jaeger_storage:
+      backends:
+        main_store:
+          memory:
+            max_traces: 100000
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+        http:
+          endpoint: 0.0.0.0:4318
+  processors:
+    batch: {}
+  exporters:
+    jaeger_storage_exporter:
+      trace_storage: main_store
+EOF
+
+    jaeger_helm_path=jaegertracing/jaeger
+    if [ "$OFFLINE" = false ]; then
+        $kube $helm repo add jaegertracing https://jaegertracing.github.io/helm-charts 2>/dev/null || true
+        $kube $helm repo update jaegertracing 2>/dev/null || true
+    else
+        jaeger_helm_path=$OFFLINE_HELMCHART_JAEGER
+    fi
+
+    $kube $helm install jaeger $jaeger_helm_path -n $NAMESPACE -f jaeger.yaml --wait
+    if [ $? -eq 0 ]; then
+        echo -e "\n${GREEN}Jaeger installed${NOCOLOR}"
+    else
+        echo -e "\n${RED}Error installing Jaeger${NOCOLOR}"
+        exit 1
+    fi
+
+    echo -e "${ORANGE}Installing OTel Collector...${NOCOLOR}"
+    cat >otel-collector.yaml <<"EOF"
+mode: deployment
+fullnameOverride: otel-collector
+image:
+  repository: otel/opentelemetry-collector-contrib
+config:
+  exporters:
+    otlphttp/jaeger:
+      traces_endpoint: http://jaeger:4318/v1/traces
+      tls:
+        insecure: true
+    otlphttp/victoriatraces:
+      traces_endpoint: http://victoria-traces:10428/insert/opentelemetry/v1/traces
+      tls:
+        insecure: true
+  service:
+    pipelines:
+      traces:
+        receivers: [otlp]
+        processors: [memory_limiter, batch]
+        exporters: [otlphttp/jaeger, otlphttp/victoriatraces]
+EOF
+
+    otel_collector_helm_path=open-telemetry/opentelemetry-collector
+    if [ "$OFFLINE" = false ]; then
+        $kube $helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts 2>/dev/null || true
+        $kube $helm repo update open-telemetry 2>/dev/null || true
+    else
+        otel_collector_helm_path=$OFFLINE_HELMCHART_OTEL_COLLECTOR
+    fi
+
+    $kube $helm install otel-collector $otel_collector_helm_path -n $NAMESPACE -f otel-collector.yaml --wait
+    if [ $? -eq 0 ]; then
+        echo -e "\n${GREEN}OTel Collector installed${NOCOLOR}"
+    else
+        echo -e "\n${RED}Error installing OTel Collector${NOCOLOR}"
+        exit 1
     fi
 }
 


### PR DESCRIPTION
This pull request introduces a comprehensive observability stack to the Lamassu IoT Helm charts and deployment scripts. It adds OpenTelemetry (OTel) instrumentation and configuration to all core services, enables deployment of Victoria Logs, VictoriaTraces, Jaeger, and an OTel Collector, and provides HTTP routes for accessing observability UIs through the API Gateway. The changes also enhance the deployment script to support both online and offline modes for the observability stack.

The most important changes are:

**Observability Configuration and Instrumentation:**
* Added a new `observability` section to `values.yaml` to centralize configuration for OpenTelemetry, including toggles for enabling instrumentation, backend endpoints, and UI routes for logs, traces, and Jaeger.
* Injected OTel configuration blocks into all core service ConfigMaps (`alert-configmap.yml`, `aws-connector-configmap.yml`, `ca-configmap.yml`, `device-manager-configmap.yml`, `dms-manager-configmap.yml`, `kms-configmap.yml`, `va-configmap.yaml`) when observability is enabled, wiring up traces and logs exporters to the configured endpoints. [[1]](diffhunk://#diff-c4b17aefbd5da9ab73125778b32579b3112a84f2ad96fa6a67fd9d650dfef738R59-R75) [[2]](diffhunk://#diff-ded42e1f6ffc7287784f5e75d153091332e50fea8866034c27f0a0bb8b7efc45R63-R79) [[3]](diffhunk://#diff-24e93dad814b720ed77e433bc501505c2e38e59c7c46b476f8966aca3757bddbR57-R73) [[4]](diffhunk://#diff-7f6cca72b3c27a0f4a298ce1e198e5ea403ebcf85e002d2a48c2e093e5773fbeR76-R92) [[5]](diffhunk://#diff-bce565a228de92712e0466417c07a0e41217fdd96f4e5112ddfe3fabc8c2c524R100-R116) [[6]](diffhunk://#diff-ff096c1529dabb563b9064d9ad04b6642e771ec79758e2067b7e61927ea4bb6aR44-R60) [[7]](diffhunk://#diff-a18ef47868575f39ac4913f42eae179b21cec3c053ea3aabdbaa20048b79fa3fR89-R105)

**API Gateway Routing for Observability UIs:**
* Added a new template `observability-httproutes.yaml` to expose Victoria Logs, VictoriaTraces, and Jaeger UIs via HTTPRoute resources, including path rewrites and redirects for correct UI behavior behind the gateway.

**Deployment Script Enhancements (`lamassu-fast-lane.sh`):**
* Added support for a new `--otel` flag and related Helm chart path flags to deploy the full observability stack in both online and offline modes, including input validation for required charts. [[1]](diffhunk://#diff-c8d88062314a6c49eb30af61ed678f39dfacf991a00bb3d329cebd01bfada9bbR14) [[2]](diffhunk://#diff-c8d88062314a6c49eb30af61ed678f39dfacf991a00bb3d329cebd01bfada9bbR44-R47) [[3]](diffhunk://#diff-c8d88062314a6c49eb30af61ed678f39dfacf991a00bb3d329cebd01bfada9bbR79-R96) [[4]](diffhunk://#diff-c8d88062314a6c49eb30af61ed678f39dfacf991a00bb3d329cebd01bfada9bbR114-R120) [[5]](diffhunk://#diff-c8d88062314a6c49eb30af61ed678f39dfacf991a00bb3d329cebd01bfada9bbR144-R148) [[6]](diffhunk://#diff-c8d88062314a6c49eb30af61ed678f39dfacf991a00bb3d329cebd01bfada9bbR297-R339)
* Automatically enables observability in the generated `lamassu.yaml` configuration when the `--otel` flag is used.

These changes collectively enable full-stack observability for Lamassu IoT deployments, making it easy to collect, view, and analyze traces and logs across all services.